### PR TITLE
Reduce memory requirements

### DIFF
--- a/src/ssort_chpl/SuffixSort.chpl
+++ b/src/ssort_chpl/SuffixSort.chpl
@@ -69,8 +69,10 @@ proc computeSuffixArray(input: [], const n: input.domain.idxType) {
 
 proc computeSuffixArrayAndLCP(input: [], const n: input.domain.idxType,
                               out SA: [],
-                              out LCP: []) {
+                              out LCP) {
+  writeln("computing suffix array");
   SA = computeSuffixArray(input, n);
+  writeln("computing LCP array");
   LCP = lcpParPlcp(input, n, SA);
 }
 

--- a/src/ssort_chpl/SuffixSort.chpl
+++ b/src/ssort_chpl/SuffixSort.chpl
@@ -144,8 +144,6 @@ proc main(args: [] string) throws {
           "took ", t.elapsed(), " seconds");
   writeln(n / 1000.0 / 1000.0 / t.elapsed(), " MB/s");
 
-  Time.sleep(20);
-
   return 0;
 }
 

--- a/src/ssort_chpl/SuffixSort.chpl
+++ b/src/ssort_chpl/SuffixSort.chpl
@@ -21,6 +21,7 @@ module SuffixSort {
 
 
 config param DEFAULT_PERIOD = 133;
+config param DEFAULT_LCP_SAMPLE = 64;
 config param EXTRA_CHECKS = false;
 config param TRACE = false;
 config type CACHED_DATA_TYPE = nothing;
@@ -76,6 +77,28 @@ proc computeSuffixArrayAndLCP(input: [], const n: input.domain.idxType,
   LCP = lcpParPlcp(input, n, SA);
 }
 
+/* Compute and return the sparse PLCP array based on the input text and suffix
+   array. The sparse PLCP array can be used to compute LCP[i] while using less
+   space.
+
+   The algorithm is based upon "Permuted Longest-Common-Prefix Array" by Juha
+   Kärkkäinen, Giovanni Manzini, and Simon J. Puglisi; and also
+   "Fast Parallel Computation of Longest Common Prefixes"
+   by Julian Shun.
+*/
+proc computeSparsePLCP(thetext: [], const n: thetext.domain.idxType,
+                       const SA: [], param q=DEFAULT_LCP_SAMPLE) {
+  return doComputeSparsePLCP(thetext, n, SA, q);
+}
+
+/* Given a sparse PLCP array computed as above in computeSparsePLCP,
+   along with the parameter q and a suffix array position 'i', return
+   LCP[i]. */
+proc lookupLCP(thetext: [], const n: thetext.domain.idxType, const SA: [],
+               const sparsePLCP: [], i: n.type, param q=DEFAULT_LCP_SAMPLE) {
+  return doLookupLCP(thetext, n, SA, sparsePLCP, i, q);
+}
+
 proc main(args: [] string) throws {
   var inputFilesList: List.list(string);
 
@@ -120,6 +143,8 @@ proc main(args: [] string) throws {
   writeln("suffix array construction of ", n, " bytes ",
           "took ", t.elapsed(), " seconds");
   writeln(n / 1000.0 / 1000.0 / t.elapsed(), " MB/s");
+
+  Time.sleep(20);
 
   return 0;
 }

--- a/src/ssort_chpl/SuffixSortImpl.chpl
+++ b/src/ssort_chpl/SuffixSortImpl.chpl
@@ -1673,8 +1673,8 @@ proc lcpParPlcp(thetext: [], const n: thetext.domain.idxType, const SA: []) {
    by Julian Shun.
 
  */
-proc computeSparsePLCP(thetext: [], const n: thetext.domain.idxType,
-                       const SA: [], param q=64) {
+proc doComputeSparsePLCP(thetext: [], const n: thetext.domain.idxType,
+                         const SA: [], param q) {
   const nTasks = computeNumTasks();
   type offsetType = (offset(SA[0])).type;
 
@@ -1726,8 +1726,8 @@ proc computeSparsePLCP(thetext: [], const n: thetext.domain.idxType,
 /* Given a sparse PLCP array computed as above in computeSparsePLCP,
    along with the parameter q and a suffix array position 'i', return
    LCP[i]. */
-proc lookupLCP(thetext: [], const n: thetext.domain.idxType, const SA: [],
-               const sparsePLCP: [], param q, i: n.type) {
+proc doLookupLCP(thetext: [], const n: thetext.domain.idxType, const SA: [],
+                 const sparsePLCP: [], i: n.type, param q) {
 
   //writeln("lookupLCP i=", i, " q=", q, " sparsePLCP=", sparsePLCP);
 

--- a/src/ssort_chpl/TestFindUnique.chpl
+++ b/src/ssort_chpl/TestFindUnique.chpl
@@ -20,7 +20,7 @@
 
 module TestFindUnique {
   use FindUnique;
-  import SuffixSort.computeSuffixArrayAndLCP;
+  import SuffixSort.{computeSuffixArray, computeSparsePLCP};
 
   config const debugOutput = false;
 
@@ -64,21 +64,23 @@ module TestFindUnique {
     // computeSuffixArrayAndLCP(thetext, n=8, SA, LCP);
 
     const SA = [7, 2, 5, 0, 3, 6, 1, 4];
-    const LCP = [0, 1, 1, 3, 3, 0, 2, 2];
+    //const LCP = [0, 1, 1, 3, 3, 0, 2, 2];
+    const SparsePLCP = computeSparsePLCP(thetext, SA.size, SA);
 
     // Expected output
     const expectedMinUnique = [0, 0, 2, 0, 3, 0, 0, 0, 0];
 
     if debugOutput {
       writeln("SA: ", SA);
-      writeln("LCP: ", LCP);
+      //writeln("LCP: ", LCP);
+      writeln("SparsePLCP: ", SparsePLCP);
       writeln("thetext: ", thetext);
       writeln("fileStarts: ", fileStarts);
       writeln("expectedMinUnique: ", expectedMinUnique);
     }
 
     // Call the function
-    var result = findUnique(SA, LCP, thetext, fileStarts, ignoreDocs);
+    var result = findUnique(SA, SparsePLCP, thetext, fileStarts, ignoreDocs);
     if debugOutput {
       writeln("Result: ", result);
     }
@@ -127,19 +129,20 @@ module TestFindUnique {
       const thetext = bytesToArray(input);
       const fileStarts = [0, input.size];
       const ignoreDocs = [false];
-      const SA, LCP;
-      computeSuffixArrayAndLCP(thetext, n = input.size, SA, LCP);
+      const SA = computeSuffixArray(thetext, n = input.size);
+      const SparsePLCP = computeSparsePLCP(thetext, SA.size, SA);
 
       if debugOutput {
         writeln("Input: ", input);
         writeln("SA: ", SA);
-        writeln("LCP: ", LCP);
+        //writeln("LCP: ", LCP);
+        writeln("SparsePLCP: ", SparsePLCP);
         writeln("thetext: ", thetext);
         writeln("fileStarts: ", fileStarts);
         writeln("expectedMinUnique: ", expected);
       }
 
-      var result = findUnique(SA, LCP, thetext, fileStarts, ignoreDocs);
+      var result = findUnique(SA, SparsePLCP, thetext, fileStarts, ignoreDocs);
       if debugOutput {
         writeln("Result: ", result);
       }
@@ -166,19 +169,21 @@ module TestFindUnique {
       const thetext = bytesToArray(input);
       const ignoreDocs:[0..<fileStarts.size-1] bool = false;
 
-      const SA, LCP;
-      computeSuffixArrayAndLCP(thetext, n = input.size, SA, LCP);
+      const SA = computeSuffixArray(thetext, n = input.size);
+      const SparsePLCP = computeSparsePLCP(thetext, SA.size, SA);
+
 
       if debugOutput {
         writeln("Input: ", input);
         writeln("SA: ", SA);
-        writeln("LCP: ", LCP);
+        //writeln("LCP: ", LCP);
+        writeln("SparsePLCP: ", SparsePLCP);
         writeln("thetext: ", thetext);
         writeln("fileStarts: ", fileStarts);
         writeln("expectedMinUnique: ", expected);
       }
 
-      var result = findUnique(SA, LCP, thetext, fileStarts, ignoreDocs);
+      var result = findUnique(SA, SparsePLCP, thetext, fileStarts, ignoreDocs);
 
       if debugOutput {
         writeln("Result: ", result);

--- a/src/ssort_chpl/TestSuffixSort.chpl
+++ b/src/ssort_chpl/TestSuffixSort.chpl
@@ -26,6 +26,7 @@ use Math;
 use IO;
 use Sort;
 
+import SuffixSort.{computeSparsePLCP,lookupLCP};
 import SuffixSort.TRACE;
 import SuffixSort.INPUT_PADDING;
 import SuffixSort.DEFAULT_PERIOD;
@@ -720,7 +721,7 @@ proc helpSparseLCP(inputArr: [], n: int, expectSA: [] int, expectLCP: [] int,
 
   // check the lookup function
   for i in 0 ..<n {
-    var gotLCPi = lookupLCP(inputArr, n, expectSA, SparsePLCP, q, i);
+    var gotLCPi = lookupLCP(inputArr, n, expectSA, SparsePLCP, i, q);
     assert(gotLCPi == expectLCP[i]);
   }
 }
@@ -947,6 +948,26 @@ proc testOthers() {
 
   testOther("banana$", [6,5,3,1,0,4,2]);
   testLCP("banana$", [6,5,3,1,0,4,2], [0,0,1,3,0,0,2]);
+
+
+  /*
+
+  abaababa
+  01234567
+
+  here is the suffix array and LCP:
+            SA         LCP
+  a         7          0
+  aababa    2          1
+  aba       5          1
+  abaababa  0          3
+  ababa     3          3
+  ba        6          0
+  baababa   1          2
+  baba      4          2
+  */
+  testOther("abaababa", [7,2,5,0,3,6,1,4]);
+  testLCP("abaababa", [7,2,5,0,3,6,1,4], [0,1,1,3,3,0,2,2]);
 }
 
 proc testRepeatsCase(c: uint(8), n: int, param period, type cachedDataType) {

--- a/src/ssort_chpl/TestSuffixSort.chpl
+++ b/src/ssort_chpl/TestSuffixSort.chpl
@@ -127,10 +127,11 @@ private proc checkSeeressesCase(type offsetType,
                               cover=new differenceCover(period));
 
   if expectCached.type != nothing {
-    const A = buildAllOffsets(cfg, inputArr, n);
+    const A = buildAllOffsets(cfg, inputArr, n, {0..<n});
     checkCached(A, expectCached);
   }
-  const SA = computeSuffixArrayDirectly(cfg, inputArr, n:offsetType);
+  const SA = computeSuffixArrayDirectly(cfg, inputArr, n:offsetType,
+                                        {0..<n:offsetType});
   checkOffsets(SA, expectOffsets);
   assert(SA.eltType.cacheType == cachedDataType);
 

--- a/src/ssort_chpl/TestSuffixSort.chpl
+++ b/src/ssort_chpl/TestSuffixSort.chpl
@@ -717,12 +717,22 @@ proc helpSparseLCP(inputArr: [], n: int, expectSA: [] int, expectLCP: [] int,
   for i in SparsePLCP.domain {
     assert(SparsePLCP[i] == PLCP[i*q]);
   }
+
+  // check the lookup function
+  for i in 0 ..<n {
+    var gotLCPi = lookupLCP(inputArr, n, expectSA, SparsePLCP, q, i);
+    assert(gotLCPi == expectLCP[i]);
+  }
 }
 
 proc checkSparseLCP(inputArr: [], n: int, expectSA: [] int, expectLCP: [] int) {
   helpSparseLCP(inputArr, n, expectSA, expectLCP, 1);
   helpSparseLCP(inputArr, n, expectSA, expectLCP, 2);
+  helpSparseLCP(inputArr, n, expectSA, expectLCP, 3);
   helpSparseLCP(inputArr, n, expectSA, expectLCP, 4);
+  helpSparseLCP(inputArr, n, expectSA, expectLCP, 5);
+  helpSparseLCP(inputArr, n, expectSA, expectLCP, 6);
+  helpSparseLCP(inputArr, n, expectSA, expectLCP, 7);
   helpSparseLCP(inputArr, n, expectSA, expectLCP, 8);
   helpSparseLCP(inputArr, n, expectSA, expectLCP, 16);
   helpSparseLCP(inputArr, n, expectSA, expectLCP, 32);
@@ -973,7 +983,7 @@ proc testRepeatsCase(c: uint(8), n: int, param period, type cachedDataType) {
 
   // check also the LCP
   var expectLCP: [0..<n] int = 0..<n;
-  testLCPRepeats(inputArr, n, expectSA, expectLCP);
+  testLCP(inputArr, n, expectSA, expectLCP);
 }
 
 proc testRepeats() {


### PR DESCRIPTION
* Use Sparse PLCP to reduce LCP array construction time
* Use a workaround to avoid additional memory in ssortDcx for returning the array with declared return type (see https://github.com/chapel-lang/chapel/issues/25741 ).