### PR TITLE
Improve suffix sort for larger problems

### DIFF
--- a/src/ssort_chpl/SuffixSort.chpl
+++ b/src/ssort_chpl/SuffixSort.chpl
@@ -45,6 +45,7 @@ private use Utility;
 private import IO;
 private import Time;
 private import List;
+private import Help;
 
 proc computeSuffixArray(input: [], const n: input.domain.idxType) {
   if !(input.domain.rank == 1 &&
@@ -99,18 +100,31 @@ proc lookupLCP(thetext: [], const n: thetext.domain.idxType, const SA: [],
   return doLookupLCP(thetext, n, SA, sparsePLCP, i, q);
 }
 
+proc usage(args: [] string) {
+  writeln("usage: ", args[0], " <files-and-directories>");
+  writeln("this program times the suffix array computation");
+  Help.printUsage();
+}
+
 proc main(args: [] string) throws {
   var inputFilesList: List.list(string);
 
   for arg in args[1..] {
+    if arg == "--help" || arg == "-h" {
+      usage(args);
+      return 0;
+    }
     if arg.startsWith("-") {
-      halt("argument not handled ", arg);
+      writeln("argument not handled ", arg);
+      usage(args);
+      return 1;
     }
     gatherFiles(inputFilesList, arg);
   }
 
   if inputFilesList.size == 0 {
     writeln("please specify input files and directories");
+    usage(args);
     return 1;
   }
 

--- a/src/ssort_chpl/SuffixSortImpl.chpl
+++ b/src/ssort_chpl/SuffixSortImpl.chpl
@@ -42,7 +42,7 @@ import SuffixSort.INPUT_PADDING;
 config const sampleRatio = 1.5;
 config const partitionSortSample = true;
 config const partitionSortAll = true;
-config param improvedSortAll = false; // TODO: fix this and then default
+config param improvedSortAll = true;
 config const seed = 1;
 config const minBucketsPerTask = 8;
 config const minBucketsSpace = 2_000_000; // a size in bytes
@@ -1156,7 +1156,7 @@ proc doSortSuffixesCompletely(const cfg:ssortConfig(?),
   }
 
 
-  if !IMPROVED_SORT_ALL {
+  if numBits(wordType) != numBits(cfg.offsetType) || !IMPROVED_SORT_ALL {
     sortRegion(A, new finalComparator(), region=region);
 
   } else {

--- a/src/ssort_chpl/SuffixSortImpl.chpl
+++ b/src/ssort_chpl/SuffixSortImpl.chpl
@@ -1457,6 +1457,7 @@ proc ssortDcx(const cfg:ssortConfig(?), const thetext, n: cfg.offsetType,
     // Replace the values in SampleText with
     // 1-based ranks from the suffix array.
     forall (offset,rank) in zip(SubSA, SubSA.domain) {
+      // TODO: use a more compactified addressing here
       SampleText[offset.offset] = rank+1;
     }
     //writeln("SampleText is ", SampleText);

--- a/src/ssort_chpl/SuffixSortImpl.chpl
+++ b/src/ssort_chpl/SuffixSortImpl.chpl
@@ -1340,6 +1340,8 @@ proc ssortDcx(const cfg:ssortConfig(?), const thetext, n: cfg.offsetType,
 
   //// Step 1: Sort Sample Suffixes ////
 
+  // TODO: allocate output array here in order to avoid memory fragmentation
+
   // begin by computing the input text for the recursive subproblem
   var SampleText:[0..<sampleN+INPUT_PADDING] subCfg.characterType;
   var allSamplesHaveUniqueRanks = false;


### PR DESCRIPTION
This activates the linear-work suffix sorting from PR #32 along with some minor changes to get testing to pass.

Future Work: use the old implementation for small enough problems.