### PR TITLE
Use atomics instead of locks

### DIFF
--- a/src/ssort_chpl/TestUtility.chpl
+++ b/src/ssort_chpl/TestUtility.chpl
@@ -129,10 +129,30 @@ proc testFastaFiles() throws {
   FileSystem.remove(filename);
 }
 
+config const n = 100_000;
+proc testAtomicMinMax() {
+
+  var amin: atomic int = max(int);
+  var amax: atomic int = min(int);
+
+  forall i in 1..n {
+    atomicStoreMinRelaxed(amin, i);
+    atomicStoreMaxRelaxed(amax, i);
+  }
+
+  writeln("amin ", amin.read(), " amax ", amax.read());
+  assert(amin.read() == 1);
+  assert(amax.read() == n);
+}
+
 proc main() throws {
   testTriangles();
   testBsearch();
   testFastaFiles();
+  serial {
+    testAtomicMinMax();
+  }
+  testAtomicMinMax();
 }
 
 

--- a/src/ssort_chpl/Utility.chpl
+++ b/src/ssort_chpl/Utility.chpl
@@ -357,4 +357,29 @@ proc printSuffix(offset: int, thetext: [], fileStarts: [] int, lcp: int, amt: in
 }
 
 
+proc atomicStoreMinRelaxed(ref dst: atomic int, src: int) {
+  // TODO: call atomic store min once issue #22867 is resolved
+  var t = dst.read(memoryOrder.relaxed);
+  while min(src, t) != t {
+    // note: dst.compareExchangeWeak updates 't' if it fails
+    // to the current value
+    if dst.compareExchangeWeak(t, src, memoryOrder.relaxed) {
+      return;
+    }
+  }
+}
+
+proc atomicStoreMaxRelaxed(ref dst: atomic int, src: int) {
+  // TODO: call atomic store max once issue #22867 is resolved
+  var t = dst.read(memoryOrder.relaxed);
+  while max(src, t) != t {
+    // note: dst.compareExchangeWeak updates 't' if it fails
+    // to the current value
+    if dst.compareExchangeWeak(t, src, memoryOrder.relaxed) {
+      return;
+    }
+  }
+}
+
+
 }


### PR DESCRIPTION
Following PR #35. We can't have per-task copies of the pairwise scores. However, we've seen the lock approach have poor performance. This PR updates it to use relaxed atomics which seems to have better performance in my testing.