### PR TITLE
Update for Chapel 2.2, test SuffixSimilarity, and clean up config consts

### DIFF
--- a/src/ssort_chpl/ExtractUniqueKmers.chpl
+++ b/src/ssort_chpl/ExtractUniqueKmers.chpl
@@ -22,10 +22,16 @@
 module ExtractUniqueKmers {
 
 
-config const INPUT:string;
-config const UNIQUE:string;
-config const REPLACE_FILENAME:string;
-config const K: int = 0;
+config const input:string; // input file
+config const unique:string; // .unique file from FindUnique
+config const replaceFilename:string; // use this filename in the output
+config const k: int = 0; // K as in KMER (common prefix length)
+
+// upper-case names for the config constants to better identify them in code
+const INPUT = input;
+const UNIQUE = unique;
+const REPLACE_FILENAME = replaceFilename;
+const K = k;
 
 use Utility;
 

--- a/src/ssort_chpl/FindUnique.chpl
+++ b/src/ssort_chpl/FindUnique.chpl
@@ -23,14 +23,23 @@ module FindUnique {
 /* the output directory */
 config const output="";
 
-config const REMOVE_NEAR_DUPLICATES = false;
-config const MIN_UNIQUE = 10; // discard some near-duplicates if there
-                              // aren't this many per file
+config const removeNearDuplicates = false;
+config const minUnique = 10; // discard some near-duplicates if there
+                             // aren't this many per file
 
-config const MAX_DUPLICATE_STEPS = 10;
-config const MAX_SIMILAR = 0.98; // maximum similarity score to allow
-                                 // when processing near-duplicates
-config const HISTOGRAM_WIDTH = 50; // how wide to make histogram chart
+config const maxDuplicateSteps = 10; // max tries removing near duplicates
+config const maxSimilar = 0.98; // maximum similarity score to allow
+                                // when processing near-duplicates
+config const histogramWidth = 50; // how wide to make histogram chart
+
+// upper-case names for the config constants to better identify them in code
+const OUTPUT = output;
+const REMOVE_NEAR_DUPLICATES = removeNearDuplicates;
+const MIN_UNIQUE = minUnique;
+const MAX_DUPLICATE_STEPS = maxDuplicateSteps;
+const MAX_SIMILAR = maxSimilar;
+const HISTOGRAM_WIDTH = histogramWidth;
+
 param HISTOGRAM_MIN = 0;
 param HISTOGRAM_MAX = 255;
 

--- a/src/ssort_chpl/Partitioning.chpl
+++ b/src/ssort_chpl/Partitioning.chpl
@@ -27,7 +27,7 @@ import SuffixSort.EXTRA_CHECKS;
 
 import Utility.computeNumTasks;
 import Reflection.canResolveMethod;
-import Sort.{sort, DefaultComparator};
+import Sort.{sort, DefaultComparator, keyPartStatus};
 import Math.{log2, divCeil};
 import CTypes.c_array;
 
@@ -66,8 +66,9 @@ private inline proc myCompareByPart(a, b, comparator) {
   while true {
     var (aSection, aPart) = comparator.keyPart(a, curPart);
     var (bSection, bPart) = comparator.keyPart(b, curPart);
-    if aSection != 0 || bSection != 0 {
-      return aSection - bSection;
+    if aSection != keyPartStatus.returned ||
+       bSection != keyPartStatus.returned {
+      return aSection:int - bSection:int;
     }
     if aPart < bPart {
       return -1;

--- a/src/ssort_chpl/SuffixSimilarity.chpl
+++ b/src/ssort_chpl/SuffixSimilarity.chpl
@@ -134,7 +134,7 @@ operator +(x: similarity, y: similarity) {
   return ret;
 }
 
-record similarityComparator {
+record similarityComparator : Sort.keyComparator {
   proc key(a: similarity) {
     return -a.score;
   }

--- a/src/ssort_chpl/SuffixSimilarity.chpl
+++ b/src/ssort_chpl/SuffixSimilarity.chpl
@@ -353,7 +353,9 @@ proc computeSimilarityBlockLCP(ref Similarity: [] similarity,
                                targetBlockSize: int,
                                minCommonStrLen: int)
 {
-  writeln("in computeSimilarityBlockLCP");
+  writeln("in computeSimilarityBlockLCP",
+          " targetBlockSize=", targetBlockSize,
+          " minCommonStrLen=", minCommonStrLen);
   // The idea of this function is to account for long similar
   // sequences as well as shorter ones.
   //
@@ -440,111 +442,122 @@ proc computeSimilarityBlockLCP(ref Similarity: [] similarity,
     const block = blockStart..blockEnd;
     //writeln("Working on block ", blockIdx, " with range ", block);
 
-    // Compute the LCP array for this block
-    var LCP:[blockStart..blockEnd] int;
-    forall (i, lcpEntry) in zip(LCP.domain, LCP) {
-      lcpEntry = lookupLCP(thetext, n, SA, SparsePLCP, i);
-    }
+    // skip empty blocks to avoid issue #26222
+    if blockEnd >= blockStart {
 
-    // compute the minimum LCP in this block
-    var minLCP = min reduce LCP[blockStart..blockEnd];
-    minLCP = max(0, minLCP);
-
-    // limit minLCP to avoid crossing file boundaries
-    for i in block {
-      const off = offset(SA[i]);
-      const doc = offsetToFileIdx(fileStarts, off);
-      const nextFileStarts = fileStarts[doc+1];
-      minLCP = min(minLCP, nextFileStarts - off - 1);
-    }
-
-    var DocToCountsThisBlock:[0..<nFiles] int = 0;
-
-    /*writeln("Block has minLCP=", minLCP);
-    for i in blockStart-1..blockEnd+1 {
-      if 0 <= i && i < n {
-        write("i", i, " ");
-        printSuffix(offset(SA[i]), thetext, fileStarts, LCP[i], minLCP+1);
+      // Compute the LCP array for this block
+      var LCP:[blockStart..blockEnd] int;
+      forall (i, lcpEntry) in zip(LCP.domain, LCP) {
+        lcpEntry = lookupLCP(thetext, n, SA, SparsePLCP, i);
       }
-    }*/
 
-    // Loop over the block to
-    //  1. Count the number of times each file occurs in the block
-    //  2. Compute the score contribution from adjacent suffixes
-    for i in block {
+      // compute the minimum LCP in this block
+      var minLCP = min reduce LCP[blockStart..blockEnd];
+      minLCP = max(0, minLCP);
 
-      // LCP indicates the common prefix between SA[i-1] and SA[i]
-      var curLCP = LCP[i];
-
-      const curOff = offset(SA[i]);
-      const curDoc = offsetToFileIdx(fileStarts, curOff);
-      const curDocEnds = fileStarts[curDoc+1];
-
-      const prevOff = offset(SA[i-1]);
-      const prevDoc = offsetToFileIdx(fileStarts, prevOff);
-      const prevDocEnds = fileStarts[prevDoc+1];
-
-      // Count the number of times each file occurs in the block
-      DocToCountsThisBlock[curDoc] += 1;
-
-      // Limit curLCP to avoid crossing file boundaries
-      curLCP = min(curLCP, curDocEnds - curOff - 1, prevDocEnds - prevOff - 1);
-
-      if curLCP > minLCP && curLCP >= minCommonStrLen && curDoc != prevDoc {
-        // ### accumulate score information for adjacent suffixes ###
-        const docA = min(curDoc, prevDoc);
-        const docB = max(curDoc, prevDoc);
-        const lcpR = curLCP: real;
-        //const score = SqFileSize[docB] * lcpR + SqFileSize[docA] * lcpR;
-        //const score = lcpR * (SqFileSize[docA] + SqFileSize[docB]);
-        //const score = lcpR;
-        const score = lcpR * (FileSufArrSize[docB] + FileSufArrSize[docA]);
-
-        const idx = flattenTriangular(docA, docB);
-        AccumCoOccurences[idx].accum(score, 1, curLCP);
-
-        // add the contribution to the denominator
-        //const sqScore = score * score;
-        //SumSqTermCounts[docA] += sqScore;
-        //SumSqTermCounts[docB] += sqScore;
+      // limit minLCP to avoid crossing file boundaries
+      for i in block {
+        const off = offset(SA[i]);
+        const doc = offsetToFileIdx(fileStarts, off);
+        const nextFileStarts = fileStarts[doc+1];
+        minLCP = min(minLCP, nextFileStarts - off - 1);
       }
-    }
 
-    // ### accumulate score information for being together in the block ###
-    if minLCP >= minCommonStrLen {
-      // compute the contribution to the denominator
-      /*foreach doc in 0..<nFiles {
-        const count = DocToCountsThisBlock[doc];
-        if count > 0 {
-          //const score = minLCP: real * DocToCountsThisBlock[doc];
-          const score = DocToCountsThisBlock[doc] : real;
-          SumSqTermCounts[doc] += score*score;
+      var DocToCountsThisBlock:[0..<nFiles] int = 0;
+
+      /*writeln("Block ", block, " has minLCP=", minLCP);
+      for i in blockStart-1 .. blockEnd+1 {
+        if 0 <= i && i < n {
+          var lcpEntry = lookupLCP(thetext, n, SA, SparsePLCP, i);
+          write("i", i, " ");
+          printSuffix(offset(SA[i]), thetext, fileStarts, lcpEntry, minLCP+1);
         }
       }*/
 
-      // compute the contribution to the numerator
-      for docA in 0..<nFiles {
-        const countA = DocToCountsThisBlock[docA];
-        if countA > 0 {
-          for docB in docA+1..<nFiles {
-            const countB = DocToCountsThisBlock[docB];
-            if countB > 0 {
-              const lcpR = minLCP : real;
-              //const score = lcpR * countA * SqFileSize[docB] +
-              //              lcpR * countB * SqFileSize[docA];
-              //const score = lcpR * (countA * SqFileSize[docB] +
-              //                      countB * SqFileSize[docA]);
-              //const score = lcpR * (countA + countB);
-              const score = lcpR * (countA * FileSufArrSize[docB] +
-                                    countB * FileSufArrSize[docA]);
-              const numPrefixes = min(countA, countB);
+      // Loop over the block to
+      //  1. Count the number of times each file occurs in the block
+      //  2. Compute the score contribution from adjacent suffixes
+      for i in block {
 
-              const idx = flattenTriangular(docA, docB);
-              AccumCoOccurences[idx].accum(score, numPrefixes, minLCP);
+        // LCP indicates the common prefix between SA[i-1] and SA[i]
+        var curLCP = LCP[i];
+
+        const curOff = offset(SA[i]);
+        const curDoc = offsetToFileIdx(fileStarts, curOff);
+        const curDocEnds = fileStarts[curDoc+1];
+
+        const prevOff = offset(SA[i-1]);
+        const prevDoc = offsetToFileIdx(fileStarts, prevOff);
+        const prevDocEnds = fileStarts[prevDoc+1];
+
+        // Count the number of times each file occurs in the block
+        DocToCountsThisBlock[curDoc] += 1;
+        if i == blockStart {
+          // also count the previous entry, since LCP[i] indicates
+          // similarity with that.
+          DocToCountsThisBlock[prevDoc] += 1;
+        }
+
+        // Limit curLCP to avoid crossing file boundaries
+        curLCP = min(curLCP, curDocEnds - curOff - 1, prevDocEnds - prevOff - 1);
+
+        if curLCP > minLCP && curLCP >= minCommonStrLen && curDoc != prevDoc {
+          // ### accumulate score information for adjacent suffixes ###
+          const docA = min(curDoc, prevDoc);
+          const docB = max(curDoc, prevDoc);
+          const lcpR = curLCP: real;
+          //const score = SqFileSize[docB] * lcpR + SqFileSize[docA] * lcpR;
+          //const score = lcpR * (SqFileSize[docA] + SqFileSize[docB]);
+          //const score = lcpR;
+          const score = lcpR * (FileSufArrSize[docB] + FileSufArrSize[docA]);
+
+          const idx = flattenTriangular(docA, docB);
+          AccumCoOccurences[idx].accum(score, 1, curLCP);
+
+          // add the contribution to the denominator
+          //const sqScore = score * score;
+          //SumSqTermCounts[docA] += sqScore;
+          //SumSqTermCounts[docB] += sqScore;
+        }
+      }
+
+      // ### accumulate score information for being together in the block ###
+      if minLCP >= minCommonStrLen {
+        // compute the contribution to the denominator
+        /*foreach doc in 0..<nFiles {
+          const count = DocToCountsThisBlock[doc];
+          if count > 0 {
+            //const score = minLCP: real * DocToCountsThisBlock[doc];
+            const score = DocToCountsThisBlock[doc] : real;
+            SumSqTermCounts[doc] += score*score;
+          }
+        }*/
+
+        // compute the contribution to the numerator
+        for docA in 0..<nFiles {
+          const countA = DocToCountsThisBlock[docA];
+          if countA > 0 {
+            for docB in docA+1..<nFiles {
+              const countB = DocToCountsThisBlock[docB];
+              if countB > 0 {
+                const lcpR = minLCP : real;
+                //const score = lcpR * countA * SqFileSize[docB] +
+                //              lcpR * countB * SqFileSize[docA];
+                //const score = lcpR * (countA * SqFileSize[docB] +
+                //                      countB * SqFileSize[docA]);
+                //const score = lcpR * (countA + countB);
+                const score = lcpR * (countA * FileSufArrSize[docB] +
+                                      countB * FileSufArrSize[docA]);
+                const numPrefixes = min(countA, countB);
+
+                const idx = flattenTriangular(docA, docB);
+                AccumCoOccurences[idx].accum(score, numPrefixes, minLCP);
+              }
             }
           }
         }
       }
+
     }
   }
 
@@ -890,6 +903,7 @@ proc computeSimilarity(SA: [], SparsePLCP: [], thetext: [],
                        fileStarts: [] int,
                        targetBlockSize: int = TARGET_BLOCK_SIZE,
                        minCommonStrLen: int = MIN_COMMON) {
+
   const nFiles = fileStarts.size-1;
   var Similarity:[0..<triangleSize(nFiles)] similarity;
   forall (i, j) in {0..<nFiles,0..<nFiles} {

--- a/src/ssort_chpl/SuffixSimilarity.chpl
+++ b/src/ssort_chpl/SuffixSimilarity.chpl
@@ -20,19 +20,35 @@
 module SuffixSimilarity {
 
 
+config const strategy="block-lcp"; // the default strategy to use
+
 // this size * the number of files = the window size
-config const STRATEGY="block-lcp";
-config const WINDOW_SIZE_RATIO = 2.5;
-config const WINDOW_SIZE_OVERRIDE = 0;
-config const NSIMILAR_TO_OUTPUT = 200;
-config const MIN_SCORE_TO_OUTPUT = 0.0;
+config const windowSizeRatio = 2.5;
+config const windowSizeOverride = 0;
 
-// these control adaptive-lcp and block-lcp
-config const MAX_BLOCK_SIZE = 1000;
-config const MIN_COMMON = 60;
-config const MAX_OCCURRENCES = 1000;
-config const TARGET_BLOCK_SIZE = 1000;
+// limit output to this many most similar
+config const nSimilarToOutput = 200;
+// limit output to at least this similarity score
+config const minScoreToOutput = 0.0;
 
+// knobs for block-lcp
+config const minCommon = 60; // consider only common substrings longer than this
+config const targetBlockSize = 1000; // target size for blocks to analyze
+
+// knobs for other algorithms
+config const maxBlockSize = 1000;
+config const maxOccurrences = 1000;
+
+// upper-case names for the config constants to better identify them in code
+const STRATEGY=strategy;
+const WINDOW_SIZE_RATIO = windowSizeRatio;
+const WINDOW_SIZE_OVERRIDE = windowSizeOverride;
+const NSIMILAR_TO_OUTPUT = nSimilarToOutput;
+const MIN_SCORE_TO_OUTPUT = minScoreToOutput;
+const MAX_BLOCK_SIZE = maxBlockSize;
+const MIN_COMMON = minCommon;
+const MAX_OCCURRENCES = maxOccurrences;
+const TARGET_BLOCK_SIZE = targetBlockSize;
 
 import SuffixSort.INPUT_PADDING;
 import SuffixSort.EXTRA_CHECKS;

--- a/src/ssort_chpl/SuffixSortImpl.chpl
+++ b/src/ssort_chpl/SuffixSortImpl.chpl
@@ -39,13 +39,22 @@ import SuffixSort.INPUT_PADDING;
 
 // how much more should we sample to create splitters?
 // 1.0 would be only to sample enough for the splitters
-config const SAMPLE_RATIO = 1.5;
-config const PARTITION_SORT_SAMPLE = true;
-config const PARTITION_SORT_ALL = true;
-config param IMPROVED_SORT_ALL = false; // TODO: fix this and then default
-config const SEED = 1;
-config const MIN_BUCKETS_PER_TASK = 8;
-config const MIN_BUCKETS_SPACE = 2_000_000; // a size in bytes
+config const sampleRatio = 1.5;
+config const partitionSortSample = true;
+config const partitionSortAll = true;
+config param improvedSortAll = false; // TODO: fix this and then default
+config const seed = 1;
+config const minBucketsPerTask = 8;
+config const minBucketsSpace = 2_000_000; // a size in bytes
+
+// upper-case names for the config constants to better identify them in code
+const SAMPLE_RATIO = sampleRatio;
+const PARTITION_SORT_SAMPLE = partitionSortSample;
+const PARTITION_SORT_ALL = partitionSortAll;
+const IMPROVED_SORT_ALL = improvedSortAll;
+const SEED = seed;
+const MIN_BUCKETS_PER_TASK = minBucketsPerTask;
+const MIN_BUCKETS_SPACE = minBucketsSpace;
 
 /**
  This record contains the configuration for the suffix sorting

--- a/src/ssort_chpl/TestSuffixSimilarity.chpl
+++ b/src/ssort_chpl/TestSuffixSimilarity.chpl
@@ -1,0 +1,173 @@
+/*
+  2024 Michael Ferguson <michaelferguson@acm.org>
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  femto/src/ssort_chpl/TestSuffixSimilarity.chpl
+*/
+
+module TestSuffixSimilarity {
+
+
+use SuffixSimilarity;
+use Utility;
+import SuffixSort.{computeSuffixArray, computeSparsePLCP, INPUT_PADDING};
+import Random;
+
+config const debugOutput = false;
+
+proc testDuplicates(docLen:int, nDocs: int) {
+  writeln("testDuplicates(", docLen, ",", nDocs, ")");
+
+  assert(docLen > 1);
+  assert(nDocs > 1);
+
+  // note: this code assumes docLen includes a null byte
+  const n = docLen * nDocs;
+
+  var allData: [0..<n+INPUT_PADDING] uint(8);
+  var allPaths: [0..<nDocs] string;
+  var concisePaths: [0..<nDocs] string;
+  var fileSizes: [0..<nDocs] int;
+  var fileStarts: [0..nDocs] int;
+  var totalSize: int = n;
+
+  // set up each file
+  forall doc in 0..<nDocs {
+    const docStart = doc*docLen;
+    forall i in 0..<docLen {
+      allData[docStart+i] = (i%10 + 97):uint(8);
+    }
+    // make sure last byte in each doc is 0, to separate
+    allData[docStart+docLen-1] = 0;
+
+    allPaths[doc] = "t" + (doc:string);
+    concisePaths[doc] = allPaths[doc];
+    fileSizes[doc] = docLen;
+    fileStarts[doc] = docStart;
+  }
+  fileStarts[nDocs] = n;
+
+  // compute the suffix array
+  const SA = computeSuffixArray(allData, totalSize);
+  if debugOutput {
+    writeln("allData");
+    writeln(allData);
+    writeln("SA");
+    writeln(SA);
+  }
+
+  // compute the sparse PLCP array
+  const SparsePLCP = computeSparsePLCP(allData, n, SA);
+
+  // compute the similarity
+  const Similarity = computeSimilarity(SA, SparsePLCP, allData, fileStarts,
+                                       targetBlockSize = max(2, docLen / 2),
+                                       minCommonStrLen = max(1, docLen / 4));
+
+  for (i, j) in {0..<nDocs,0..<nDocs} {
+    if i < j {
+      var sim = Similarity[flattenTriangular(i,j)];
+      if debugOutput {
+        writeln("score for (", i, " vs ", j, ") = ", sim.score);
+      }
+      assert(sim.score > 0.3);
+    }
+  }
+}
+
+proc testRandom(docLen:int, nDocs: int) {
+  writeln("testRandom(", docLen, ",", nDocs, ")");
+
+  assert(docLen > 1);
+  assert(nDocs > 1);
+
+  // note: this code assumes docLen includes a null byte
+  const n = docLen * nDocs;
+
+  var allData: [0..<n+INPUT_PADDING] uint(8);
+  var allPaths: [0..<nDocs] string;
+  var concisePaths: [0..<nDocs] string;
+  var fileSizes: [0..<nDocs] int;
+  var fileStarts: [0..nDocs] int;
+  var totalSize: int = n;
+
+  Random.fillRandom(allData, seed=17);
+
+  // set up each file
+  forall doc in 0..<nDocs {
+    const docStart = doc*docLen;
+    // make sure last byte in each doc is 0, to separate
+    allData[docStart+docLen-1] = 0;
+
+    allPaths[doc] = "t" + (doc:string);
+    concisePaths[doc] = allPaths[doc];
+    fileSizes[doc] = docLen;
+    fileStarts[doc] = docStart;
+  }
+  fileStarts[nDocs] = n;
+
+  // compute the suffix array
+  const SA = computeSuffixArray(allData, totalSize);
+  if debugOutput {
+    writeln("allData");
+    writeln(allData);
+    writeln("SA");
+    writeln(SA);
+  }
+
+  // compute the sparse PLCP array
+  const SparsePLCP = computeSparsePLCP(allData, n, SA);
+
+  // compute the similarity
+  const Similarity = computeSimilarity(SA, SparsePLCP, allData, fileStarts,
+                                       targetBlockSize = max(2, docLen / 2),
+                                       minCommonStrLen = max(1, docLen / 4));
+
+  for (i, j) in {0..<nDocs,0..<nDocs} {
+    if i < j {
+      var sim = Similarity[flattenTriangular(i,j)];
+      if debugOutput {
+        writeln("score for (", i, " vs ", j, ") = ", sim.score);
+      }
+      assert(sim.score < 0.1);
+    }
+  }
+}
+
+
+proc runTests() {
+  testDuplicates(3, 2);
+  testDuplicates(10, 2);
+  testDuplicates(10, 3);
+  testDuplicates(10, 4);
+  testRandom(10, 2);
+  testRandom(10, 3);
+  testRandom(10, 4);
+}
+
+
+// Run the tests
+proc main() {
+  serial {
+    runTests();
+  }
+
+  runTests();
+
+  writeln("OK");
+}
+
+
+}


### PR DESCRIPTION
* Updates for Chapel 2.2 to avoid deprecation warnings about Sort stuff
* Fixes a bug in SuffixSimilarity and adds basic testing for it
* Adjust config consts to be camelCase rather than UPPER_CASE to make the command line experience nicer. Config params are still UPPER_CASE.