### PR TITLE
Track FASTA sequence boundaries and optionally descriptions

### DIFF
--- a/src/ssort_chpl/Checksum.chpl
+++ b/src/ssort_chpl/Checksum.chpl
@@ -56,33 +56,68 @@ proc main(args: [] string) throws {
   const allData; //: [] uint(8);
   const allPaths; //: [] string;
   const concisePaths; // : [] string
-  const fileSizes; //: [] int;
   const fileStarts; //: [] int;
   const totalSize: int;
+  const sequenceDescriptions; //: [] string;
+  const sequenceStarts; //: [] int;
   readAllFiles(inputFilesList,
                Locales,
                allData=allData,
                allPaths=allPaths,
                concisePaths=concisePaths,
-               fileSizes=fileSizes,
                fileStarts=fileStarts,
-               totalSize=totalSize);
+               totalSize=totalSize,
+               sequenceDescriptions=sequenceDescriptions,
+               sequenceStarts=sequenceStarts);
 
-  writeln("Files are: ", concisePaths);
+  /*writeln("Files are:");
+  for p in concisePaths {
+    writeln(" ", p);
+  }
   writeln("FileStarts are: ", fileStarts);
+  writeln("Sequences are:");
+  for (d,i) in zip(sequenceDescriptions, 0..) {
+    writeln(" ", i, " ", d);
+  }
+  writeln("SequenceStarts are: ", sequenceStarts);*/
+
   reportTime(readTime, "reading input", totalSize, 1);
 
   var chksumTime = startTime(true);
-  const allChecksums;
-  hashAllFiles(allData, allPaths, fileStarts, totalSize, allChecksums);
-  reportTime(chksumTime, "checksum", totalSize, 1);
+  const allFileChecksums;
+  hashAllFiles(allData, fileStarts, totalSize, allFileChecksums);
+  const allSeqChecksums;
+  hashAllFiles(allData, sequenceStarts, totalSize, allSeqChecksums);
+  reportTime(chksumTime, "checksum", 2*totalSize, 1);
 
-  for (f, chksum) in zip(allPaths, allChecksums) {
+  for idx in 0..<allPaths.size {
+    const f = allPaths[idx];
+    const chksum = allFileChecksums[idx];
+
     for i in 0..<chksum.size {
       writef("%08xu", chksum[i]);
     }
     write("  ");
     write(f);
+    writeln();
+  }
+
+  for idx in 0..<sequenceDescriptions.size {
+    const d = sequenceDescriptions[idx];
+    const chksum = allSeqChecksums[idx];
+
+    /*var dataregion = sequenceStarts[idx]..<sequenceStarts[idx+1];
+    writeln("data in ", dataregion, " for ", d, ":");
+    for j in dataregion {
+      writef("%c", allData[j]);
+    }
+    writeln();*/
+
+    for i in 0..<chksum.size {
+      writef("%08xu", chksum[i]);
+    }
+    write("  ");
+    write(d);
     writeln();
   }
 

--- a/src/ssort_chpl/Checksum.chpl
+++ b/src/ssort_chpl/Checksum.chpl
@@ -68,7 +68,8 @@ proc main(args: [] string) throws {
                fileStarts=fileStarts,
                totalSize=totalSize,
                sequenceDescriptions=sequenceDescriptions,
-               sequenceStarts=sequenceStarts);
+               sequenceStarts=sequenceStarts,
+               skipDescriptions=false);
 
   /*writeln("Files are:");
   for p in concisePaths {

--- a/src/ssort_chpl/CopyData.chpl
+++ b/src/ssort_chpl/CopyData.chpl
@@ -1,0 +1,90 @@
+/*
+  2025 Michael Ferguson <michaelferguson@acm.org>
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  femto/src/ssort_chpl/CopyData.chpl
+*/
+
+module CopyData {
+
+private import List;
+private import Help;
+
+private use Utility;
+
+config const output: string = "";
+
+proc usage(args: [] string) {
+  writeln("usage: ", args[0], " --output <filename> <files-and-directories>");
+  writeln("this program reads in files and outputs the data to one file");
+  Help.printUsage();
+}
+
+proc main(args: [] string) throws {
+  var inputFilesList: List.list(string);
+
+  for arg in args[1..] {
+    if arg == "--help" || arg == "-h" {
+      usage(args);
+      return 0;
+    }
+    if arg.startsWith("-") {
+      writeln("argument not handled ", arg);
+      usage(args);
+      return 1;
+    }
+    gatherFiles(inputFilesList, arg);
+  }
+
+  if inputFilesList.size == 0 {
+    writeln("please specify input files and directories");
+    usage(args);
+    return 1;
+  }
+
+  if output == "" {
+    writeln("please specify an output file");
+    usage(args);
+    return 1;
+  }
+
+  var readTime = startTime(true);
+  const allData; //: [] uint(8);
+  const allPaths; //: [] string;
+  const concisePaths; // : [] string
+  const fileStarts; //: [] int;
+  const totalSize: int;
+  const sequenceDescriptions; //: [] string;
+  const sequenceStarts; //: [] int;
+  readAllFiles(inputFilesList,
+               Locales,
+               allData=allData,
+               allPaths=allPaths,
+               concisePaths=concisePaths,
+               fileStarts=fileStarts,
+               totalSize=totalSize,
+               sequenceDescriptions=sequenceDescriptions,
+               sequenceStarts=sequenceStarts);
+
+  reportTime(readTime, "reading input", totalSize, 1);
+
+  writeln("Saving output to ", output);
+  writeBlockArray(output, allData, 0..<totalSize);
+
+  return 0;
+}
+
+
+}

--- a/src/ssort_chpl/ExtractUniqueKmers.chpl
+++ b/src/ssort_chpl/ExtractUniqueKmers.chpl
@@ -51,9 +51,13 @@ proc main() throws {
   }
 
   const isFasta = isFastaFile(INPUT);
-  const n = computeFileSize(INPUT);
+  var (n, nSequences) = computeFileSize(INPUT);
+  var SeqDescriptions:[0..<nSequences] string;
+  var SeqStarts:[0..nSequences] int;
   var Text:[0..n] uint(8);
-  readFileData(INPUT, Text, 0..<n, verbose=false);
+  readFileData(INPUT, Text, 0..<n,
+               seqStartIdx=0, SeqDescriptions, SeqStarts,
+               verbose=false);
 
   var uniqueF = IO.open(UNIQUE, IO.ioMode.r);
   const n2 = uniqueF.size;

--- a/src/ssort_chpl/ExtractUniqueKmers.chpl
+++ b/src/ssort_chpl/ExtractUniqueKmers.chpl
@@ -36,8 +36,16 @@ const K = k;
 use Utility;
 
 import IO;
+import List;
 import OS.EofError;
 import Path;
+
+proc normalizeDesc(in desc: string) {
+  desc = desc.strip(">", leading=true, trailing=false);
+  desc = desc.replace(" ", "_");
+  desc = desc.replace("\t", "_");
+  return desc;
+}
 
 proc main() throws {
   if INPUT == "" {
@@ -51,13 +59,27 @@ proc main() throws {
   }
 
   const isFasta = isFastaFile(INPUT);
-  var (n, nSequences) = computeFileSize(INPUT);
-  var SeqDescriptions:[0..<nSequences] string;
-  var SeqStarts:[0..nSequences] int;
-  var Text:[0..n] uint(8);
-  readFileData(INPUT, Text, 0..<n,
-               seqStartIdx=0, SeqDescriptions, SeqStarts,
-               verbose=false);
+
+  var inputFilesList: List.list(string);
+  inputFilesList.pushBack(INPUT);
+
+  const allData; //: [] uint(8);
+  const allPaths; //: [] string;
+  const concisePaths; // : [] string
+  const fileStarts; //: [] int;
+  const totalSize: int;
+  const sequenceDescriptions; //: [] string;
+  const sequenceStarts; //: [] int;
+  readAllFiles(inputFilesList,
+               Locales,
+               allData=allData,
+               allPaths=allPaths,
+               concisePaths=concisePaths,
+               fileStarts=fileStarts,
+               totalSize=totalSize,
+               sequenceDescriptions=sequenceDescriptions,
+               sequenceStarts=sequenceStarts,
+               skipDescriptions=false);
 
   var uniqueF = IO.open(UNIQUE, IO.ioMode.r);
   const n2 = uniqueF.size;
@@ -65,62 +87,21 @@ proc main() throws {
   uniqueF.reader().readAll(MinUnique);
   uniqueF.close();
 
+  const n = totalSize - 1; // ignore trailing null byte
+
   if n != n2 {
     halt("File sizes do not match" +
          "-- does the input file correspond to the unique file?");
   }
+
 
   var useFilename = Path.basename(INPUT);
   if !REPLACE_FILENAME.isEmpty() {
     useFilename = REPLACE_FILENAME;
   }
 
-  var desc = "-";
-  if isFasta {
-    var r = IO.openReader(INPUT);
-    // read the description
-    // ASSUMPTION: other sections of the file are the same organism
-
-    // process the input file, Text, and MinUnique together
-    // use the input file just to get the descriptions
-    var textOffset: int = 0;
-
-    // read until next description
-    try {
-      r.advanceTo(">");
-      r.readLine(desc, stripNewline=true);
-      // verify that Text[textOffset] is a >
-      if Text[textOffset] != ">".toByte() {
-        halt("Contig misalignment");
-      }
-      textOffset += 1;
-    } catch e: EofError {
-      desc = "eof";
-    }
-    // check that the first line matches
-    var check: bytes;
-    r.mark();
-    // read until we get a non-empty line
-    while r.readLine(check, stripNewline=true) &&
-          !check.isEmpty() {
-    }
-    r.revert();
-
-    desc = desc.strip(">", leading=true, trailing=false);
-    desc = desc.replace(" ", "_");
-    desc = desc.replace("\t", "_");
-
-    // verify that 'check' matches Text[textOffset..]
-    if !check.isEmpty() {
-      var len = min(n - textOffset, check.size);
-      for i in 0..len {
-        if Text[textOffset+i] != check[i] {
-          halt("Nucleotide did not match");
-        }
-      }
-    }
-  }
-
+  var curDesc: string = "-";
+  var curSequence = -1;
   for i in 0..<n {
     const len = MinUnique[i]: int;
     if len > 0 && (K == 0 || len <= K) {
@@ -133,18 +114,24 @@ proc main() throws {
         var ignoreDueToSequenceBoundary = false;
         if isFasta {
           for j in 0..<useK {
-            if Text[startOffset+j] == ">".toByte() {
+            if allData[startOffset+j] == ">".toByte() {
               ignoreDueToSequenceBoundary = true;
             }
           }
         }
 
         if !ignoreDueToSequenceBoundary {
+          var seqIdx = offsetToFileIdx(sequenceStarts, i);
+          if curSequence != seqIdx {
+            curSequence = seqIdx;
+            curDesc = sequenceDescriptions[curSequence];
+            curDesc = normalizeDesc(curDesc);
+          }
           for j in 0..<useK {
-            writef("%c", Text[startOffset + j]);
+            writef("%c", allData[startOffset + j]);
           }
 
-          write(" 0 ", useFilename, " 1 ", desc, " ", i);
+          write(" 0 ", useFilename, " 1 ", curDesc, " ", i);
           writeln();
         }
       }

--- a/src/ssort_chpl/FindUnique.chpl
+++ b/src/ssort_chpl/FindUnique.chpl
@@ -81,8 +81,9 @@ inline proc adjustForFileBoundaries(count, offset: int, doc: int,
 }
 
 /* Find substrings that are unique to a document.
-   Returns a 'record hits' which needs to be sorted
-   to remove unnecessary hits.
+   Returns an array MinUnique of size 'n' where
+   MinUnique[i] = x means that at offset i there is
+   an x-character long unique sequence.
 
    If IgnoreDocs[doc] is true, entries from that file will be ignored.
  */
@@ -472,20 +473,22 @@ proc main(args: [] string) throws {
   const allData; //: [] uint(8);
   const allPaths; //: [] string;
   const concisePaths; // : [] string
-  const fileSizes; //: [] int;
   const fileStarts; //: [] int;
   const totalSize: int;
+  const sequenceDescriptions; //: [] string;
+  const sequenceStarts; //: [] int;
   readAllFiles(inputFilesList,
                Locales,
                allData=allData,
                allPaths=allPaths,
                concisePaths=concisePaths,
-               fileSizes=fileSizes,
                fileStarts=fileStarts,
-               totalSize=totalSize);
+               totalSize=totalSize,
+               sequenceDescriptions=sequenceDescriptions,
+               sequenceStarts=sequenceStarts);
 
-  writeln("Files are: ", concisePaths);
-  writeln("FileStarts are: ", fileStarts);
+  /*writeln("Files are: ", concisePaths);
+  writeln("FileStarts are: ", fileStarts);*/
 
   var t: Time.stopwatch;
 

--- a/src/ssort_chpl/FindUnique.chpl
+++ b/src/ssort_chpl/FindUnique.chpl
@@ -573,7 +573,7 @@ proc main(args: [] string) throws {
       }
     }
 
-    Sort.sort(MaximumNearDuplicateScore, new Sort.ReverseComparator());
+    Sort.sort(MaximumNearDuplicateScore, new Sort.reverseComparator());
 
     var half = nNearDuplicates/2;
     half = max(1, half);

--- a/src/ssort_chpl/SHA256Implementation.chpl
+++ b/src/ssort_chpl/SHA256Implementation.chpl
@@ -1,0 +1,394 @@
+/*
+
+This module implements the SHA256 cryptographic hash algorithm.
+
+*/
+module SHA256Implementation {
+
+  // This implementation is based on FIPS 180-4 and uses some
+  // hints from other implementations for reducing the number
+  // of instructions in the basic functions.
+
+  /* This record stores the state of the hash. */
+  record SHA256State {
+    var length:uint(64); // length of hashed message, in bits
+    var H:8*uint(32);    // current hash
+  };
+
+  /* This function simply casts the passed integer to a uint(32) */
+  inline proc ul(x) {
+    return x:uint(32);
+  }
+  /* This function casts each portion of the passed tuple
+     to uint(32) and returns the result. */
+  inline proc ul(x:8*int) {
+    var ret:8*uint(32);
+    for i in 0..7 {
+      ret[i] = x[i]:uint(32);
+    }
+    return ret;
+  }
+
+
+  // The K constants
+  private
+  var K:64*uint(32) =
+(ul(0x428a2f98), ul(0x71374491), ul(0xb5c0fbcf), ul(0xe9b5dba5), ul(0x3956c25b),
+ ul(0x59f111f1), ul(0x923f82a4), ul(0xab1c5ed5), ul(0xd807aa98), ul(0x12835b01),
+ ul(0x243185be), ul(0x550c7dc3), ul(0x72be5d74), ul(0x80deb1fe), ul(0x9bdc06a7),
+ ul(0xc19bf174), ul(0xe49b69c1), ul(0xefbe4786), ul(0x0fc19dc6), ul(0x240ca1cc),
+ ul(0x2de92c6f), ul(0x4a7484aa), ul(0x5cb0a9dc), ul(0x76f988da), ul(0x983e5152),
+ ul(0xa831c66d), ul(0xb00327c8), ul(0xbf597fc7), ul(0xc6e00bf3), ul(0xd5a79147),
+ ul(0x06ca6351), ul(0x14292967), ul(0x27b70a85), ul(0x2e1b2138), ul(0x4d2c6dfc),
+ ul(0x53380d13), ul(0x650a7354), ul(0x766a0abb), ul(0x81c2c92e), ul(0x92722c85),
+ ul(0xa2bfe8a1), ul(0xa81a664b), ul(0xc24b8b70), ul(0xc76c51a3), ul(0xd192e819),
+ ul(0xd6990624), ul(0xf40e3585), ul(0x106aa070), ul(0x19a4c116), ul(0x1e376c08),
+ ul(0x2748774c), ul(0x34b0bcb5), ul(0x391c0cb3), ul(0x4ed8aa4a), ul(0x5b9cca4f),
+ ul(0x682e6ff3), ul(0x748f82ee), ul(0x78a5636f), ul(0x84c87814), ul(0x8cc70208),
+ ul(0x90befffa), ul(0xa4506ceb), ul(0xbef9a3f7), ul(0xc67178f2));
+
+  // The logical functions
+
+  // Rotate right
+  private inline
+  proc ROTR(x:uint(32), y:uint(32)):uint(32) {
+    use BitOps;
+    return rotr(x & ul(0xffffffff), y & 31);
+  }
+
+  private inline
+  proc Ch(x:uint(32), y:uint(32), z:uint(32)):uint(32) {
+    return z ^ (x & (y ^ z));
+  }
+
+  private inline
+  proc Maj(x:uint(32), y:uint(32), z:uint(32)):uint(32) {
+    return ((x | y) & z) | (x & y);
+  }
+
+  // Shift right
+  private inline
+  proc SHR(x:uint(32), n:uint(32)):uint(32) {
+    return (x & ul(0xffffffff)) >> n;
+  }
+
+  private inline
+  proc Sigma0(x:uint(32)):uint(32) {
+    return ROTR(x, 2) ^ ROTR(x, 13) ^ ROTR(x, 22);
+  }
+
+  private inline
+  proc Sigma1(x:uint(32)):uint(32) {
+    return ROTR(x, 6) ^ ROTR(x, 11) ^ ROTR(x, 25);
+  }
+
+  private inline
+  proc Gamma0(x:uint(32)):uint(32) {
+    return ROTR(x, 7) ^ ROTR(x, 18) ^ SHR(x, 3);
+  }
+
+  private inline
+  proc Gamma1(x:uint(32)):uint(32) {
+    return ROTR(x, 17) ^ ROTR(x, 19) ^ SHR(x, 10);
+  }
+
+  // hash computation
+  private
+  proc sha256_compute(ref state:SHA256State, msg:16*uint(32)) {
+    var W:64*uint(32);
+
+    // Prepare the message schedule
+    for i in 0..15 {
+      W[i] = msg[i];
+    }
+    for i in 16..63 {
+      W[i] = Gamma1(W[i - 2]) + W[i - 7] + Gamma0(W[i - 15]) + W[i - 16];
+    }
+
+    // Initialize the working variables
+    var a = state.H[0];
+    var b = state.H[1];
+    var c = state.H[2];
+    var d = state.H[3];
+    var e = state.H[4];
+    var f = state.H[5];
+    var g = state.H[6];
+    var h = state.H[7];
+
+    for i in 0..63 {
+      var t1:uint(32);
+      var t2:uint(32);
+      t1 = h + Sigma1(e) + Ch(e, f, g) + K[i] + W[i];
+      t2 = Sigma0(a) + Maj(a, b, c);
+      h = g;
+      g = f;
+      f = e;
+      e = d + t1;
+      d = c;
+      c = b;
+      b = a;
+      a = t1 + t2;
+    }
+
+    // compute the intermediate hash value
+    state.H[0] += a;
+    state.H[1] += b;
+    state.H[2] += c;
+    state.H[3] += d;
+    state.H[4] += e;
+    state.H[5] += f;
+    state.H[6] += g;
+    state.H[7] += h;
+
+  }
+
+  // Set the bit numbered `bit` in `msg`.
+  // Bit numbering starts with 0. Bit numbers 0-31 are in msg(1)
+  // and bit 0 is the most-significant.
+  private
+  proc set_bit(ref msg:16*uint(32), bit:uint) {
+    assert(bit < 512);
+    var whichword = ul(bit / 32);
+    var inword = ul(bit % 32);
+    msg[whichword] |= ul(1) << (31 - inword);
+  }
+
+  // Clear the bits after bit `nbits` in `msg`.
+  // Bit numbering starts with 0. Bit numbers 0-31 are in msg(1)
+  // and bit 0 is the most-significant.
+  private
+  proc clear_bits_after(ref msg:16*uint(32), nbits:uint) {
+    assert(nbits < 512);
+    var whichword = ul(nbits / 32);
+    var inword = ul(nbits % 32);
+
+    var word:uint(32) = msg[whichword];
+    // Clear the bits after inword in word
+    var zero:uint(32) = 0;
+    var ones:uint(32) = ~zero;
+    var mask:uint(32);
+    if inword == 0 then
+      mask = 0;
+    else
+      mask = ones << (32-inword);
+    word &= mask;
+    msg[whichword] = word;
+
+    // Clear the remaining words
+    for i in whichword+1..15 {
+      msg[i] = 0;
+    }
+  }
+
+  /* Initialize a SHA256State so that it can perform hash computations. */
+  proc SHA256State.init() {
+    this.length = 0;
+
+    this.H = ul( (0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+                  0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19) );
+  }
+
+  /* Processes 512 bits of message.
+     This function can be called an arbitrary number of times
+     to compute the hash for a long message.
+
+     Note, the `msg` words should already be in native byte order.
+     That means the caller probably needed to already run big-endian-to-host
+     on the message.
+   */
+  proc ref SHA256State.fullblock(msg:16*uint(32)) {
+    this.length += 512;
+    sha256_compute(this, msg);
+
+    /*write("fullblock ");
+    for x in msg {
+      writef("%08xu", x);
+    }
+    writeln();*/
+  }
+
+  /* Process the final <= 512 bits of message.
+     Computes and returns the final hash.
+
+     As with SHA256State.fullblock, the msg words should already be
+     in native byte order. That means the caller probably needed to already run
+     big-endian-to-host on the message.
+
+     nbits is the number of bits in msg to use
+   */
+  proc ref SHA256State.lastblock(in msg:16*uint(32), in nbits:uint):8*uint(32)
+  {
+    /*write("lastblock nbits=", nbits, " ");
+    for x in msg {
+      writef("%08xu", x);
+    }
+    writeln();*/
+
+    this.length += nbits;
+
+    // This routine is handling padding the message
+    if nbits == 512 {
+      sha256_compute(this, msg);
+      nbits = 0;
+    }
+    // Append the 1 bit
+    set_bit(msg, nbits);
+    nbits += 1;
+    // clear the last 512 - bits of the message
+    clear_bits_after(msg, nbits);
+
+    // Now we need to pad zeros so there is room to store the 8 bytes of
+    if nbits > 512 - 64 {
+      sha256_compute(this, msg);
+      nbits = 0;
+      clear_bits_after(msg, nbits);
+    }
+
+    // Now store the 64-bit length quantity in the last two words
+    // of the message.
+    msg[14] = ul((this.length >> 32) & ul(0xffffffff));
+    msg[15] = ul(this.length & ul(0xffffffff));
+
+    // hash the final block
+    sha256_compute(this, msg);
+
+    /*write("lastblock returning ");
+    for x in this.H {
+      writef("%08xu", x);
+    }
+    writeln();*/
+
+    return this.H;
+  }
+
+  /* This function exists to test private methods in this module and can
+     be called to run a sequence of unit tests. */
+  proc unittest() {
+    var zeros:16*uint(32);
+    var ones:16*uint(32);
+    var msg:16*uint(32);
+
+    for i in 0..15 {
+      ones[i] = ~zeros[i];
+    }
+
+    msg = ones;
+    clear_bits_after(msg, 0);
+    assert(msg[0] == 0 && msg[1] == 0 && msg[15] == 0);
+
+    msg = ones;
+    clear_bits_after(msg, 1);
+    assert(msg[0] == 0x80000000 && msg[1] == 0 && msg[15] == 0);
+
+    msg = ones;
+    clear_bits_after(msg, 2);
+    assert(msg[0] == 0xc0000000 && msg[1] == 0 && msg[15] == 0);
+
+    msg = ones;
+    clear_bits_after(msg, 31);
+    assert(msg[0] == 0xfffffffe && msg[1] == 0 && msg[15] == 0);
+
+    msg = ones;
+    clear_bits_after(msg, 32);
+    assert(msg[0] == 0xffffffff && msg[1] == 0 && msg[15] == 0);
+
+    msg = ones;
+    clear_bits_after(msg, 33);
+    assert(msg[0] == 0xffffffff && msg[1] == 0x80000000 &&
+           msg[3] == 0 && msg[15] == 0);
+
+    msg = ones;
+    clear_bits_after(msg, 34);
+    assert(msg[0] == 0xffffffff && msg[1] == 0xc0000000 &&
+           msg[3] == 0 && msg[15] == 0);
+
+    msg = zeros;
+    set_bit(msg, 0);
+    assert(msg[0] == 0x80000000 && msg[1] == 0);
+
+    msg = zeros;
+    set_bit(msg, 1);
+    assert(msg[0] == 0x40000000 && msg[1] == 0);
+
+    msg = zeros;
+    set_bit(msg, 2);
+    assert(msg[0] == 0x20000000 && msg[1] == 0);
+
+    msg = zeros;
+    set_bit(msg, 31);
+    assert(msg[0] == 0x00000001 && msg[1] == 0);
+
+    msg = zeros;
+    set_bit(msg, 32);
+    assert(msg[0] == 0 && msg[1] == 0x80000000 && msg[3] == 0);
+
+    msg = zeros;
+    set_bit(msg, 33);
+    assert(msg[0] == 0 && msg[1] == 0x40000000 && msg[3] == 0);
+
+
+    var startingState:SHA256State;
+    var state:SHA256State;
+    var hash:8*uint(32);
+
+    state = startingState;
+    msg = zeros;
+    msg[0] = 0x61000000;
+    hash = state.lastblock(msg, 1*8);
+    assert(hash==ul( ( 0xca978112, 0xca1bbdca, 0xfac231b3, 0x9a23dc4d,
+                       0xa786eff8, 0x147c4e72, 0xb9807785, 0xafee48bb) ));
+
+    // Try hashing varying lengths of 0 bytes
+    // These tests help ensure we have the padding right
+
+    // 0 bytes
+    state = startingState;
+    hash = state.lastblock(zeros, 0);
+
+    assert(hash==ul( (0xe3b0c442, 0x98fc1c14, 0x9afbf4c8, 0x996fb924,
+		      0x27ae41e4, 0x649b934c, 0xa495991b, 0x7852b855) ));
+
+
+    // 55 bytes
+    state = startingState;
+    hash = state.lastblock(zeros, 55*8);
+
+    assert(hash==ul( (0x02779466, 0xcdec1638, 0x11d07881, 0x5c633f21,
+                      0x90141308, 0x1449002f, 0x24aa3e80, 0xf0b88ef7) ));
+
+    // 56 bytes
+    state = startingState;
+    hash = state.lastblock(zeros, 56*8);
+    assert(hash==ul( (0xd4817aa5, 0x497628e7, 0xc77e6b60, 0x6107042b,
+                      0xbba31308, 0x88c5f47a, 0x375e6179, 0xbe789fbb) ));
+
+    // 119 bytes
+    state = startingState;
+    state.fullblock(zeros); // 64 bytes
+    hash = state.lastblock(zeros, 55*8);
+    assert(hash==ul((0xf616b0d5, 0x4e78571a, 0x9611f343, 0xc9f8e022,
+                     0xe859e920, 0x381ab0e4, 0xd3da01e1, 0x93a7bd7e) ));
+
+    // 120 bytes
+    state = startingState;
+    state.fullblock(zeros); // 64 bytes
+    hash = state.lastblock(zeros, 56*8);
+    assert(hash==ul((0x6edd9f6f, 0x9cc92cde, 0xd36e6c4a, 0x580933f9,
+                     0xc9f1b905, 0x62b46903, 0xb806f219, 0x02a1a54f) ));
+
+    // 128 bytes
+    state = startingState;
+    state.fullblock(zeros);
+    hash = state.lastblock(zeros, 64*8);
+    assert(hash==ul( (0x38723a2e, 0x5e8a17aa, 0x7950dc00, 0x8209944e,
+                      0x898f69a7, 0xbd10a23c, 0x839d341e, 0x935fd5ca) ));
+
+    // 129 bytes
+    state = startingState;
+    state.fullblock(zeros);
+    state.fullblock(zeros);
+    hash = state.lastblock(zeros, 1*8);
+    assert(hash==ul( (0x2c80619d, 0x7e7c5825, 0x7293cda3, 0xa878c13e,
+                      0x5856f4e0, 0x6f6f9060, 0x1276f7b9, 0x179c9e07) ));
+  }
+}

--- a/src/ssort_chpl/SuffixSimilarity.chpl
+++ b/src/ssort_chpl/SuffixSimilarity.chpl
@@ -955,20 +955,22 @@ proc main(args: [] string) throws {
   const allData; //: [] uint(8);
   const allPaths; //: [] string;
   const concisePaths; //: [] string;
-  const fileSizes; //: [] int;
   const fileStarts; //: [] int;
   const totalSize: int;
+  const sequenceDescriptions; //: [] string;
+  const sequenceStarts; //: [] int;
   readAllFiles(inputFilesList,
                Locales,
                allData=allData,
                allPaths=allPaths,
                concisePaths=concisePaths,
-               fileSizes=fileSizes,
                fileStarts=fileStarts,
-               totalSize=totalSize);
+               totalSize=totalSize,
+               sequenceDescriptions=sequenceDescriptions,
+               sequenceStarts=sequenceStarts);
 
-  writeln("Files are: ", concisePaths);
-  writeln("FileStarts are: ", fileStarts);
+  /*writeln("Files are: ", concisePaths);
+  writeln("FileStarts are: ", fileStarts);*/
 
   var t: Time.stopwatch;
 

--- a/src/ssort_chpl/SuffixSort.chpl
+++ b/src/ssort_chpl/SuffixSort.chpl
@@ -181,20 +181,22 @@ proc main(args: [] string) throws {
   const allData; //: [] uint(8);
   const allPaths; //: [] string;
   const concisePaths; // : [] string
-  const fileSizes; //: [] int;
   const fileStarts; //: [] int;
   const totalSize: int;
+  const sequenceDescriptions; //: [] string;
+  const sequenceStarts; //: [] int;
   readAllFiles(inputFilesList,
                Locales,
                allData=allData,
                allPaths=allPaths,
                concisePaths=concisePaths,
-               fileSizes=fileSizes,
                fileStarts=fileStarts,
-               totalSize=totalSize);
+               totalSize=totalSize,
+               sequenceDescriptions=sequenceDescriptions,
+               sequenceStarts=sequenceStarts);
 
-  writeln("Files are: ", concisePaths);
-  writeln("FileStarts are: ", fileStarts);
+  //writeln("Files are: ", concisePaths);
+  //writeln("FileStarts are: ", fileStarts);
   reportTime(readTime, "reading input", totalSize, 1);
 
   const n = min(TRUNCATE_INPUT_TO, totalSize);

--- a/src/ssort_chpl/TestUtility.chpl
+++ b/src/ssort_chpl/TestUtility.chpl
@@ -364,7 +364,7 @@ proc testFastaFile(contents:string, seq:string, revcomp:string) throws {
 proc testFastaFiles() throws {
   writeln("testFastaFiles()");
 
-  testFastaFile("> test \t seq\nA\n\rC\tG  TTA\nGGT\n\n\nA\n> seq 2\nCCG",
+  testFastaFile("> test \t seq\nA\n\rC\tG  TtA\ngGT\n\n\nA\n> seq 2\nCCG",
                 ">ACGTTAGGTA>CCG",
                 ">CGG>TACCTAACGT");
   testFastaFile(">\n>\n>\nACAT\n>\n>\n", ">>>ACAT>>", ">>>ATGT>>");

--- a/src/ssort_chpl/TestUtility.chpl
+++ b/src/ssort_chpl/TestUtility.chpl
@@ -355,6 +355,7 @@ proc testFastaFile(contents:string, seq:string, revcomp:string) throws {
     var SeqDesc: [0..nseq+1] string;
     var A: [0..n+1] uint(8);
     readFastaFileSequence(filename, A, 1..n, distributed=false,
+                          skipDescriptions=false,
                           1, SeqDesc, SeqStart);
     assert(A[0] == 0);
     assert(A[n+1] == 0);
@@ -373,7 +374,8 @@ proc testFastaFile(contents:string, seq:string, revcomp:string) throws {
     SeqStart = 0;
     SeqDesc = "";
     A = 0;
-    readFileData(filename, A, 1..n, 1, SeqDesc, SeqStart);
+    readFileData(filename, A, 1..n, 1, skipDescriptions=false,
+                 SeqDesc, SeqStart);
     assert(A[0] == 0);
     assert(A[n+1] == 0);
     var str2 = arrToString(A[1..n]);

--- a/src/ssort_chpl/TestUtility.chpl
+++ b/src/ssort_chpl/TestUtility.chpl
@@ -21,6 +21,8 @@ module TestUtility {
 
 
 use Utility;
+import SHA256Implementation;
+
 import IO;
 import FileSystem;
 import BlockDist;
@@ -786,6 +788,9 @@ proc testPackInput() {
 
 proc main() throws {
   testIsDistributed();
+
+  writeln("SHA256Implementation.unittest");
+  SHA256Implementation.unittest();
 
   serial {
     testActiveLocales();

--- a/src/ssort_chpl/Utility.chpl
+++ b/src/ssort_chpl/Utility.chpl
@@ -40,7 +40,7 @@ import CopyAggregation.DstAggregator;
 import Communication;
 import OS.FileNotFoundError;
 
-use SHA256Implementation;
+import SHA256Implementation.SHA256State;
 
 import SuffixSort.{EXTRA_CHECKS, TIMING, TRACE, INPUT_PADDING,
                    DISTRIBUTE_EVEN_WITH_COMM_NONE};

--- a/src/ssort_chpl/check.bash
+++ b/src/ssort_chpl/check.bash
@@ -4,12 +4,19 @@
 # (as indicated by a nonzero exit code)
 set -e
 
+COMM=`chpl --print-chpl-settings | awk '/CHPL_COMM:/ { print $2 }'`
+
 for name in Test*.chpl
 do
   echo compiling $name : chpl $name -o a.out --set EXTRA_CHECKS=true
   chpl $name -o a.out --set EXTRA_CHECKS=true
-  echo running $name : ./a.out
-  ./a.out
+  echo running $name : ./a.out -nl 1
+  ./a.out -nl 1
+  if [[ "$COMM" != "none" ]]
+  then
+    echo running $name : ./a.out -nl 2
+    ./a.out -nl 3
+  fi
   rm a.out
 done
 

--- a/src/ssort_chpl/fasta-checksum.py
+++ b/src/ssort_chpl/fasta-checksum.py
@@ -13,37 +13,44 @@ import hashlib
 from Bio import SeqIO
 from Bio import Seq
 
-def handle_file(path):
+def hash_file(path):
     filehash = hashlib.sha256()
-    recs = [ ] 
+    recs = [ ]
     for rec in SeqIO.parse(path, "fasta"):
         recs.append(rec)
 
     # process the input
     # hash the forward sequences
     for rec in recs:
-        #print("rec.id", rec.id)
-        #print("rec.description", rec.description)
         filehash.update(b">")
         filehash.update(bytes(rec.seq.upper()))
 
     # hash the reverse complement sequences
     for rec in reversed(recs):
-        #print("rev rec.id", rec.id)
-        #print("rev rec.description", rec.description)
         filehash.update(b">")
         filehash.update(bytes(rec.seq.upper().reverse_complement()))
 
-    print(filehash.hexdigest(), " ", path)
+    print(filehash.hexdigest(), " " + path)
 
-def handle_path(path):
-    if os.path.isfile(path):
-        handle_file(path)
+def hash_sequences(path):
+    recs = [ ]
+    for rec in SeqIO.parse(path, "fasta"):
+        recs.append(rec)
 
-    if os.path.isdir(path):
-        for root, subdirs, files in os.walk(path):
-            for filename in files:
-                handle_file(os.path.join(root, filename))
+    # process the input
+    # hash the forward sequences
+    for rec in recs:
+        seqhash = hashlib.sha256()
+        seqhash.update(b">")
+        seqhash.update(bytes(rec.seq.upper()))
+        print(seqhash.hexdigest(), " >" + rec.description)
+
+    # hash the reverse complement sequences
+    for rec in reversed(recs):
+        seqhash = hashlib.sha256()
+        seqhash.update(b">")
+        seqhash.update(bytes(rec.seq.upper().reverse_complement()))
+        print(seqhash.hexdigest(), " >" + rec.description + " [revcomp]")
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
@@ -63,4 +70,7 @@ if __name__ == "__main__":
     file_paths.sort()
 
     for path in file_paths:
-        handle_file(path)
+        hash_file(path)
+
+    for path in file_paths:
+        hash_sequences(path)

--- a/src/ssort_chpl/fasta-checksum.py
+++ b/src/ssort_chpl/fasta-checksum.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+# This is a Python program to compute the checksums of fasta
+# files in the same way as the FEMTO Chapel code does.
+#
+# The goal of it is to make it easy to verify that the Chapel code
+# is doing I/O correctly.
+
+import os
+import sys
+import hashlib
+
+from Bio import SeqIO
+from Bio import Seq
+
+def handle_file(path):
+    filehash = hashlib.sha256()
+    recs = [ ] 
+    for rec in SeqIO.parse(path, "fasta"):
+        recs.append(rec)
+
+    # process the input
+    # hash the forward sequences
+    for rec in recs:
+        #print("rec.id", rec.id)
+        #print("rec.description", rec.description)
+        filehash.update(b">")
+        filehash.update(bytes(rec.seq.upper()))
+
+    # hash the reverse complement sequences
+    for rec in reversed(recs):
+        #print("rev rec.id", rec.id)
+        #print("rev rec.description", rec.description)
+        filehash.update(b">")
+        filehash.update(bytes(rec.seq.upper().reverse_complement()))
+
+    print(filehash.hexdigest(), " ", path)
+
+def handle_path(path):
+    if os.path.isfile(path):
+        handle_file(path)
+
+    if os.path.isdir(path):
+        for root, subdirs, files in os.walk(path):
+            for filename in files:
+                handle_file(os.path.join(root, filename))
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: fasta-checksup.py <files-and-directories>")
+
+    file_paths = [ ]
+
+    for path in sys.argv[1:]:
+        if os.path.isfile(path):
+            file_paths.append(path)
+
+        if os.path.isdir(path):
+            for root, subdirs, files in os.walk(path):
+                for filename in files:
+                    file_paths.append(os.path.join(root, filename))
+
+    file_paths.sort()
+
+    for path in file_paths:
+        handle_file(path)


### PR DESCRIPTION
* Improves ExtractUniqueKmers.chpl to properly identify different sequences from the same file
* To do so, readAllFiles builds an array of sequence start positions. It can optionally also gather the description for each sequence.
* To verify FASTA read behavior, added a Checksum program and a Python equivalent, fasta-checksum.py. 