### PR TITLE
Cached aggregators & improvements to ExtractUniqueKmers

### DIFF
--- a/src/ssort_chpl/CachedAggregators.chpl
+++ b/src/ssort_chpl/CachedAggregators.chpl
@@ -219,12 +219,15 @@ record perTaskLock {
   proc ref lock() {
     while this.reservedByTask != nil {
       currentTask.yieldExecution();
+      chpl_atomic_thread_fence(memory_order_acquire);
     }
+    chpl_atomic_thread_fence(memory_order_acquire);
     reservedByTask = perTaskLock.getTaskId();
   }
   proc ref unlock() {
     assert(isLockedByCurrentTask());
     reservedByTask = nil;
+    chpl_atomic_thread_fence(memory_order_release);
   }
 }
 

--- a/src/ssort_chpl/CachedAggregators.chpl
+++ b/src/ssort_chpl/CachedAggregators.chpl
@@ -1,0 +1,571 @@
+/*
+  2024 Michael Ferguson <michaelferguson@acm.org>
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  femto/src/ssort_chpl/CachedAggregators.chpl
+*/
+module CachedAggregators {
+
+
+use CopyAggregation;
+use AggregationPrimitives;
+use ChplConfig;
+use CTypes;
+use OS.POSIX;
+use Set;
+
+private param defaultBuffSize =
+  if CHPL_TARGET_PLATFORM == "hpe-cray-ex" then 1024
+  else if CHPL_COMM == "ugni" then 4096
+  else 8192;
+
+private const yieldFrequency = getEnvInt("CHPL_AGGREGATION_YIELD_FREQUENCY", 1024);
+private const dstBuffSize = getEnvInt("CHPL_AGGREGATION_DST_BUFF_SIZE", defaultBuffSize);
+private const srcBuffSize = getEnvInt("CHPL_AGGREGATION_SRC_BUFF_SIZE", defaultBuffSize);
+
+private config param aggregate = CHPL_COMM != "none";
+
+
+// it just has the same interface as DstAggregator but doesn't aggregate
+record DummyDstAggregator {
+  inline proc ref copy(ref dst: ?t, const in srcVal: t) {
+    dst = srcVal;
+  }
+  inline proc ref flush(freeBuffers=false) { }
+}
+/* "Aggregator" that uses unordered copy instead of actually aggregating */
+record DstUnorderedAggregator {
+  type elemType;
+
+  proc deinit() {
+    flush();
+  }
+  proc ref flush(freeBuffers=false) {
+    if isPOD(elemType) then unorderedCopyTaskFence();
+  }
+  inline proc ref copy(ref dst: elemType, const in srcVal: elemType) {
+    if isPOD(elemType) then unorderedCopy(dst, srcVal);
+                       else dst = srcVal;
+  }
+}
+// it just has the same interface as SrcAggregator but doesn't aggregate
+record DummySrcAggregator {
+  inline proc ref copy(ref dst: ?t, const ref src: t) {
+    if boundsChecking {
+      assert(dst.locale.id == here.id);
+    }
+    dst = src;
+  }
+  inline proc ref flush(freeBuffers=false) { }
+}
+/* "Aggregator" that uses unordered copy instead of actually aggregating */
+record SrcUnorderedAggregator {
+  type elemType;
+
+  proc deinit() {
+    flush();
+  }
+  proc ref flush(freeBuffers=false) {
+    if isPOD(elemType) then unorderedCopyTaskFence();
+  }
+  inline proc ref copy(ref dst: elemType, const ref src: elemType) {
+    if boundsChecking {
+      assert(dst.locale.id == here.id);
+    }
+    if isPOD(elemType) then unorderedCopy(dst, src);
+                       else dst = src;
+  }
+}
+
+record CachedDstAggregator {
+  var agg: borrowed CachedDstAggregatorClass;
+  proc init() {
+    var cls = PThreadSupport.getPerPthreadClass(CachedDstAggregatorClass);
+    assert(cls != nil);
+    this.agg = cls;
+  }
+  proc ref deinit() {
+    flush();
+  }
+  inline proc ref copy(ref dst: ?t, const ref src: t) {
+    this.agg.copy(dst, src);
+  }
+  inline proc ref flush() {
+    this.agg.flush(freeBuffers=false);
+  }
+}
+
+// create and destroy the per-pthread CachedDstAggregatorClass
+var perPthreadAggregators: set(eltType=unmanaged CachedDstAggregatorClass,
+                               parSafe=true);
+writeln("creating aggregators");
+coforall tid in 0..<4*here.maxTaskPar with (ref perPthreadAggregators) {
+  var cls = PThreadSupport.getPerPthreadClass(CachedDstAggregatorClass);
+  perPthreadAggregators.add(cls:unmanaged);
+}
+writeln("done creating aggregators");
+proc deinit() {
+  writeln("destroying aggregators");
+  for elt in perPthreadAggregators {
+    writeln("destroying ", c_ptrTo(elt));
+    delete elt;
+  }
+}
+
+
+/* Aggregator that can be shared, works with any type */
+class CachedDstAggregatorClass {
+  // room for dstBuffSize ints, each with a dst ptr and size
+  // (larger items will occupy more of the buffer)
+  const bufferSize = (dstBuffSize * (3*c_sizeof(c_ptr(void)))):int;
+  const myLocaleSpace = 0..<numLocales;
+  var lastLocale: int;
+  var opsUntilYield = yieldFrequency;
+  var lBuffers: c_ptr(c_ptr(uint(8)));
+  var rBuffers: [myLocaleSpace] remoteBuffer(uint(8));
+  var bufferIdxs: c_ptr(int);
+  var currentlyFlushing = false;
+
+  proc init() {
+    init this;
+    writeln("Creating CachedDstAggregatorClass ", c_ptrTo(this));
+  }
+
+  proc postinit() {
+    lBuffers = allocate(c_ptr(uint(8)), numLocales);
+    bufferIdxs = bufferIdxAlloc();
+    for loc in myLocaleSpace {
+      lBuffers[loc] = allocate(uint(8), bufferSize);
+      bufferIdxs[loc] = 0;
+      rBuffers[loc] = new remoteBuffer(uint(8), bufferSize, loc);
+    }
+  }
+
+  proc deinit() {
+    writeln("Destroying CachedDstAggregatorClass ", c_ptrTo(this));
+    flush(freeBuffers=true);
+    for loc in myLocaleSpace {
+      deallocate(lBuffers[loc]);
+    }
+    deallocate(lBuffers);
+    deallocate(bufferIdxs);
+  }
+
+  proc flush(freeBuffers=false) {
+    // TODO: try randomized flush
+    for offsetLoc in myLocaleSpace + lastLocale {
+      const loc = offsetLoc % numLocales;
+      flushBuffer(loc, bufferIdxs[loc], freeData=freeBuffers);
+    }
+  }
+
+  inline proc copy(ref dst:?t, const ref src:t) {
+    if boundsChecking {
+      assert(src.locale.id == here.id);
+    }
+
+    const loc = dst.locale.id;
+    const addr_size = c_sizeof(c_ptr(void));
+    const size_size = c_sizeof(addr_size.type);
+    const data_size = c_sizeof(t);
+    const serialize_bytes = addr_size + size_size + data_size;
+
+    // Just do direct assignment if dst is local or src size is large
+    if loc == here.id || serialize_bytes > (bufferSize >> 2) {
+      dst = src;
+      return;
+    }
+
+    lastLocale = loc;
+
+    var dstAddr = getAddr(dst);
+
+    // Get our current index into the buffer for dst's locale
+    ref bufferIdx = bufferIdxs[loc];
+
+    // Flush our buffer if this entry will exceed capacity
+    if bufferIdx + serialize_bytes > bufferSize {
+      // note: it can yield inside flushBuffer.
+      flushBuffer(loc, bufferIdx, freeData=false);
+      opsUntilYield = yieldFrequency;
+    }
+
+    const buf = lBuffers[loc];
+
+    // Buffer the address
+    memcpy(c_ptrTo(buf[bufferIdx]),
+           c_ptrTo(dstAddr),
+           addr_size);
+    bufferIdx += addr_size:int;
+    // Buffer the size
+    memcpy(c_ptrTo(buf[bufferIdx]),
+           c_ptrToConst(data_size):c_ptr(data_size.type),
+           size_size);
+    bufferIdx += size_size:int;
+    // Buffer the data
+    memcpy(c_ptrTo(buf[bufferIdx]),
+           c_ptrToConst(src):c_ptr(src.type),
+           data_size);
+    bufferIdx += data_size:int;
+
+    // If it's been a while since we've let other tasks run, yield so that
+    // we're not blocking remote tasks from flushing their buffers.
+    if opsUntilYield == 0 {
+      currentTask.yieldExecution();
+      opsUntilYield = yieldFrequency;
+    } else {
+      opsUntilYield -= 1;
+    }
+  }
+
+  proc flushBuffer(loc: int, ref bufferIdx, freeData) {
+    // return early if there's no data to flush
+    if bufferIdx == 0 then return;
+
+    // wait for some other task if it's currently doing a flush
+    while currentlyFlushing {
+      currentTask.yieldExecution();
+    }
+
+    // return early again if there's no data to flush
+    if bufferIdx == 0 then return;
+
+    // now we're the one running and currentlyFlushing was false,
+    // so it's up to us to flush! But mark that we're flushing
+    // so that if we yield, another task won't also flush.
+    currentlyFlushing = true;
+    // clear currentlyFlushing on exit from this block
+    defer { currentlyFlushing = false; }
+
+    const myBufferIdx = bufferIdx;
+
+    // Allocate a remote buffer
+    ref rBuffer = rBuffers[loc];
+    const remBufferPtr = rBuffer.cachedAlloc();
+
+    // Copy local buffer to remote buffer
+    rBuffer.PUT(lBuffers[loc], myBufferIdx);
+
+    // Process remote buffer
+    on Locales[loc] {
+      var curBufferIdx = 0;
+      while curBufferIdx < myBufferIdx {
+        const addr_size = c_sizeof(c_ptr(void));
+        const size_size = c_sizeof(addr_size.type);
+        var dstAddr: c_ptr(void);
+        var dataSize: addr_size.type;
+
+        // Copy the addr out
+        memcpy(c_ptrTo(dstAddr),
+               c_ptrTo(remBufferPtr[curBufferIdx]),
+               addr_size);
+        curBufferIdx += addr_size:int;
+        // Copy the size out
+        memcpy(c_ptrTo(dataSize),
+               c_ptrTo(remBufferPtr[curBufferIdx]),
+               size_size);
+        curBufferIdx += size_size:int;
+        // Copy the data out
+        memcpy(dstAddr, c_ptrTo(remBufferPtr[curBufferIdx]), dataSize);
+        curBufferIdx += dataSize:int;
+      }
+
+      if freeData {
+        rBuffer.localFree(remBufferPtr);
+      }
+    }
+    if freeData {
+      rBuffer.markFreed();
+    }
+    bufferIdx = 0;
+  }
+}
+
+
+module PThreadSupport {
+  use CTypes;
+  use OS;
+  use OS.POSIX;
+
+  extern type pthread_key_t;
+  extern proc pthread_key_create(ref key: pthread_key_t,
+                                 destr_function: c_fn_ptr): c_int;
+  extern proc pthread_setspecific(key: pthread_key_t, ptr: c_ptr(void)): c_int;
+  extern proc pthread_getspecific(key: pthread_key_t): c_ptr(void);
+
+  export proc pthread_key_deleter(ptr: c_ptr(void)): void {
+    // Problem: the pthread will be destroyed on program exit after
+    // the runtime doesn't exist anymore
+    /*var obj = ptr:unmanaged RootClass?;
+    if obj != nil {
+      delete obj;
+    }*/
+  }
+
+  proc keyCreate() : pthread_key_t throws {
+    var key: pthread_key_t;
+    var rc: c_int = pthread_key_create(key, c_ptrTo(pthread_key_deleter));
+    if rc != 0 {
+      throw createSystemError(rc, "error in pthread_key_create");
+    }
+
+    return key;
+  }
+
+  proc setSpecific(key: pthread_key_t, obj: c_ptr(void)) : void throws {
+    var rc: c_int = pthread_setspecific(key, obj);
+    if rc != 0 {
+      throw createSystemError(rc, "error in pthread_setspecific");
+    }
+  }
+  proc getSpecific(key: pthread_key_t) : c_ptr(void) {
+    var ptr: c_ptr(void) = pthread_getspecific(key);
+    return ptr;
+  }
+
+  proc getPerPthreadClass(type t) where isClassType(t) {
+    @functionStatic(sharingKind.computePerLocale)
+    var key = try! keyCreate();
+
+    var ptr : c_ptr(void) = getSpecific(key);
+    if ptr == nil {
+      var obj = new unmanaged t();
+
+      ptr = c_ptrTo(obj);
+      try! setSpecific(key, ptr);
+      assert(ptr != nil);
+    }
+    var cls = try! ptr:borrowed t?:borrowed t;
+    return cls;
+  }
+}
+
+/*
+pthread_key_create
+class Obj;
+
+void* pthread_getspecific(pthread_key_t key)
+  pthread_setspecific
+
+// help to implement code using Aggregators sometimes and sometimes not.
+// IMO it would be ideal to have a single per-thread aggregator associated
+// with the comms cache that allows different data types. Such an aggregator
+// would only need to be constructed once (well, maybe once for GET and once
+// for PUT) but has additional coordination challenges.
+//
+// In the meantime, we have aggregators for different types, and if these
+// are created ahead of time, we can reuse them.
+//
+// So, MaybeDstAggregator / MaybeSrcAggregator have two features
+// beyond DstAggregator / SrcAggregator:
+//
+// 1. They can be disabled in a per-instance way.
+//    When disabled, `copy` just calls `=`. This allows calling code to avoid
+//    lots of conditionals.
+// 2. They provide a mechanism for checking that the current pthread
+//    being used matches the pthread that created the aggregator.
+//    This is only used with EXTRA_CHECKS enabled.
+
+/*extern type pthread_t;
+extern proc pthread_self():pthread_t;
+extern proc pthread_equal(a: pthread_t, b:pthread_t):c_int;
+
+record MaybeDstAggregator {
+  type elemType;
+  param active: bool;        // if not, there is no aggregator
+  var pthread_id: pthread_t; // pthread owning this aggregator
+  var agg: if active then DstAggregator(elemType) else nothing;
+  proc init(type elemType, param active: bool) {
+    this.elemType = elemType;
+    this.active = active;
+    this.pthread_id = pthread_self();
+    if active {
+      this.agg = new DstAggregator(elemType);
+    } else {
+      this.agg = none;
+    }
+  }
+  inline proc ref copy(ref dst: elemType, const in srcVal: elemType) {
+    if active {
+      if EXTRA_CHECKS { assert(pthread_equal(pthread_id, pthread_self()) > 0); }
+      if EXTRA_CHECKS { assert(src.locale.id == here.id); }
+      agg.copy(dst, srcVal);
+    } else {
+      dst = srcVal;
+    }
+  }
+  inline proc ref flush(freeBuffers=false) {
+    if active {
+      if EXTRA_CHECKS { assert(pthread_equal(pthread_id, pthread_self()) > 0); }
+      agg.flush(freeBuffers=freeBuffers);
+    }
+  }
+}
+
+record MaybeSrcAggregator {
+  type elemType;
+  param active: bool;        // if not, there is no aggregator
+  var pthread_id: pthread_t; // pthread owning this aggregator
+  var agg: if active then SrcAggregator(elemType) else nothing;
+  proc init(type elemType, param active: bool) {
+    this.elemType = elemType;
+    this.active = active;
+    this.pthread_id = pthread_self();
+    if active {
+      this.agg = new SrcAggregator(elemType);
+    } else {
+      this.agg = none;
+    }
+  }
+  inline proc ref copy(ref dst: elemType, const ref src: elemType) {
+    if active {
+      if EXTRA_CHECKS { assert(pthread_equal(pthread_id, pthread_self()) > 0); }
+      if EXTRA_CHECKS { assert(dst.locale.id == here.id); }
+      agg.copy(dst, src);
+    } else {
+      dst = src;
+    }
+  }
+  inline proc ref flush(freeBuffers=false) {
+    if active {
+      if EXTRA_CHECKS { assert(pthread_equal(pthread_id, pthread_self()) > 0); }
+      agg.flush(freeBuffers=freeBuffers);
+    }
+  }
+}
+*/
+
+class SharedDstAggregator {
+  type elemType;
+  var agg: DstAggregator(elemType);
+  var inUse: bool;  // is it currently being used
+  //var inUseByPthread: pthread_t; // current pthread using it
+}
+
+record DstAggregatorGroup {
+  type elemType;
+  const nTasksPerLocale: int;
+  const Dom = blockDist.createDomain(0..<numLocales*nTasksPerLocale);
+  var PerTaskAggs: [Dom] unmanaged SharedDstAggregator?;
+  proc init(type elemType, nTasksPerLocale: int) {
+    this.elemType = elemType;
+    this.nTasksPerLocale = nTasksPerLocale;
+    init this;
+    forall (locIdx, taskIdInLoc, chunk)
+    in divideIntoTasks(Dom, Dom.dim(0), nTasksPerLocale) {
+      assert(chunk.size == 1);
+      const idx = chunk.first;
+      PerTaskAggs[idx] = new unmanaged SharedDstAggregator(elemType);
+    }
+  }
+  proc deinit() {
+    forall (locIdx, taskIdInLoc, chunk)
+    in divideIntoTasks(Dom, Dom.dim(0), nTasksPerLocale) {
+      assert(chunk.size == 1);
+      const idx = chunk.first;
+      delete PerTaskAggs[idx];
+    }
+  }
+}
+
+record FlushingDstAggregator {
+  type elemType;
+  var sharedAgg: borrowed SharedDstAggregator(elemType);
+  proc init(sharedAgg: borrowed SharedDstAggregator(?)) {
+    this.elemType = sharedAgg.elemType;
+    this.sharedAgg = sharedAgg;
+    assert(sharedAgg.inUse == false);
+    sharedAgg.inUse = true;
+  }
+  proc ref agg ref : DstAggregator(elemType) {
+    return sharedAgg.agg;
+  }
+  proc deinit() {
+    sharedAgg.agg.flush(freeBuffers=false);
+    sharedAgg.inUse = false;
+  }
+}
+
+proc DstAggregatorGroup.getAggregator(locIdx, taskIdInLoc) {
+  var aggCls = PerTaskAggs[locIdx*nTasksPerLocale+taskIdInLoc]!;
+  return new FlushingDstAggregator(elemType, aggCls);
+}
+
+
+class SharedSrcAggregator {
+  type elemType;
+  var agg: SrcAggregator(elemType);
+  var inUse: bool;  // is it currently being used
+  //var inUseByPthread: pthread_t; // current pthread using it
+}
+
+record SrcAggregatorGroup {
+  type elemType;
+  const nTasksPerLocale: int;
+  const Dom = blockDist.createDomain(0..<numLocales*nTasksPerLocale);
+  var PerTaskAggs: [Dom] unmanaged SharedSrcAggregator?;
+  proc init(type elemType, nTasksPerLocale: int) {
+    this.elemType = elemType;
+    this.nTasksPerLocale = nTasksPerLocale;
+    init this;
+    forall (locIdx, taskIdInLoc, chunk)
+    in divideIntoTasks(Dom, Dom.dim(0), nTasksPerLocale) {
+      assert(chunk.size == 1);
+      const idx = chunk.first;
+      PerTaskAggs[idx] = new unmanaged SharedSrcAggregator(elemType);
+    }
+  }
+  proc deinit() {
+    forall (locIdx, taskIdInLoc, chunk)
+    in divideIntoTasks(Dom, Dom.dim(0), nTasksPerLocale) {
+      assert(chunk.size == 1);
+      const idx = chunk.first;
+      delete PerTaskAggs[idx];
+    }
+  }
+}
+
+record FlushingSrcAggregator {
+  type elemType;
+  var sharedAgg: borrowed SharedSrcAggregator(elemType);
+  proc init(sharedAgg: borrowed SharedSrcAggregator(?)) {
+    this.elemType = sharedAgg.elemType;
+    this.sharedAgg = sharedAgg;
+    assert(sharedAgg.inUse == false);
+    sharedAgg.inUse = true;
+  }
+  proc ref agg ref : SrcAggregator(elemType) {
+    return sharedAgg.agg;
+  }
+  proc deinit() {
+    sharedAgg.agg.flush(freeBuffers=false);
+    sharedAgg.inUse = false;
+  }
+
+  proc ref agg {
+    return sharedAgg.agg;
+  }
+  proc deinit() {
+    sharedAgg.agg.flush(freeBuffers=false);
+  }
+}
+
+proc SrcAggregatorGroup.getAggregator(locIdx, taskIdInLoc) {
+  var aggCls = PerTaskAggs[locIdx*nTasksPerLocale+taskIdInLoc]!;
+  return new FlushingSrcAggregator(elemType, aggCls);
+}
+*/
+
+}

--- a/src/ssort_chpl/CachedAggregators.chpl
+++ b/src/ssort_chpl/CachedAggregators.chpl
@@ -243,6 +243,7 @@ class CachedDstAggregatorClass {
   proc flush(freeBuffers=false) {
     // TODO: try randomized flush
     // TODO: use unordered copy if too few elements to flush
+    // TODO: try double buffering
     for offsetLoc in myLocaleSpace + lastLocale {
       const loc = offsetLoc % numLocales;
       flushBuffer(loc, bufferIdxs[loc], freeData=freeBuffers);
@@ -409,6 +410,7 @@ class CachedSrcAggregatorClass {
   proc flush(freeBuffers=false) {
     // TODO: try randomized flush
     // TODO: use unordered copy if too few elements to flush
+    // TODO: try double buffering
     for offsetLoc in myLocaleSpace + lastLocale {
       const loc = offsetLoc % numLocales;
       flushBuffer(loc, bufferIdxs[loc], freeData=freeBuffers);

--- a/src/ssort_chpl/ExtractUniqueKmers.chpl
+++ b/src/ssort_chpl/ExtractUniqueKmers.chpl
@@ -22,118 +22,324 @@
 module ExtractUniqueKmers {
 
 
-config const input:string; // input file
-config const unique:string; // .unique file from FindUnique
-config const replaceFilename:string; // use this filename in the output
+config const unique:string; // dir containing .unique files from FindUnique
 config const k: int = 0; // K as in KMER (common prefix length)
+config const tsv: bool = false; // output uniquesketch tab-separated format
+config const shifts: bool = false; // output shifts
 
 // upper-case names for the config constants to better identify them in code
-const INPUT = input;
-const UNIQUE = unique;
-const REPLACE_FILENAME = replaceFilename;
+const UNIQUE_DIR = unique;
 const K = k;
+const OUTPUT_TSV = tsv;
+const SHIFTS = shifts;
 
 use Utility;
 
+import FileSystem;
 import IO;
 import List;
 import OS.EofError;
 import Path;
+import Set;
+import Sort;
 
 proc normalizeDesc(in desc: string) {
   desc = desc.strip(">", leading=true, trailing=false);
+  return desc;
+}
+
+proc replaceSpacesWithUnderlines(in desc: string) {
   desc = desc.replace(" ", "_");
   desc = desc.replace("\t", "_");
   return desc;
 }
 
-proc main() throws {
-  if INPUT == "" {
-    writeln("please use --input <filename> to specify an input file");
-    return 1;
-  }
-  if UNIQUE == "" {
-    writeln("please use --unique <filename> to specify a .unique file");
-    writeln("FindUnique can generate these");
-    return 1;
-  }
+const toEscape = (">",   "\n",  "\r",  "\\");
+const escaped  = ("\\>", "\\n", "\\r", "\\\\");
 
-  const isFasta = isFastaFile(INPUT);
+proc escapeCh(ch: uint(8)) {
+  for i in 0..<toEscape.size {
+    if toEscape(i).toByte() == ch {
+      return escaped(i);
+    }
+  }
+  assert(false); // don't call this it's not a character to escape
+  return "";
+}
+proc escapeString(in s: string) {
+  for i in 0..<toEscape.size {
+    s = s.replace(toEscape(i), escaped(i));
+  }
+  return s;
+}
 
+proc outputKmer(offset: int,
+                uniqueLen: int,
+                outputLen: int,
+                startOffsetInSequence: int,
+                uniqueOffsetInSequence: int,
+                fileIdx: int,
+                nFiles: int,
+                allData: [] uint(8),
+                useFilename: string,
+                curDesc: string,
+                isFasta: bool) {
+  if OUTPUT_TSV {
+    // output tab-separated data:
+    //  kmer
+    //  file idx (integer)
+    //  file name
+    //  num files
+    //  sequence description
+    //  kmer start position in sequence
+
+    // output the kmer
+    for j in 0..<outputLen {
+      writef("%c", allData[offset + j]);
+    }
+    // output the rest
+    writef("\t%i\t%s\t%i\t%s\t%i\n",
+           fileIdx, useFilename, nFiles, curDesc, startOffsetInSequence);
+  } else {
+    // output matches in a FASTA-ish format FASTA
+    //   >
+    //   sequence description|
+    //   filename|
+    //   kmer start in sequence
+    //   kmer len
+    //   unique start in sequence
+    //   unique len
+    // <then sequence data in separate line>
+
+    writef("> %s | %s | %i %i %i %i\n",
+           curDesc, useFilename,
+           startOffsetInSequence, outputLen,
+           uniqueOffsetInSequence, uniqueLen);
+
+    // output the kmer, with some escaping
+    for j in 0..<outputLen {
+      var ch:uint(8) = allData[offset + j];
+      if ch == ">".toByte() || ch == "\n".toByte() ||
+         ch == "\r".toByte() || ch == "\\".toByte() {
+        write(escapeCh(ch));
+      } else {
+        writef("%c", ch);
+      }
+    }
+    writeln();
+  }
+}
+
+
+proc main(args: [] string) throws {
   var inputFilesList: List.list(string);
-  inputFilesList.pushBack(INPUT);
 
-  const allData; //: [] uint(8);
-  const allPaths; //: [] string;
-  const concisePaths; // : [] string
-  const fileStarts; //: [] int;
-  const totalSize: int;
-  const sequenceDescriptions; //: [] string;
-  const sequenceStarts; //: [] int;
-  readAllFiles(inputFilesList,
-               Locales,
-               allData=allData,
-               allPaths=allPaths,
-               concisePaths=concisePaths,
-               fileStarts=fileStarts,
-               totalSize=totalSize,
-               sequenceDescriptions=sequenceDescriptions,
-               sequenceStarts=sequenceStarts,
-               skipDescriptions=false);
+  for arg in args[1..] {
+    if arg.startsWith("-") {
+      halt("argument not handled ", arg);
+    }
+    gatherFiles(inputFilesList, arg);
+  }
 
-  var uniqueF = IO.open(UNIQUE, IO.ioMode.r);
-  const n2 = uniqueF.size;
-  var MinUnique:[0..<n2] uint(8);
-  uniqueF.reader().readAll(MinUnique);
-  uniqueF.close();
-
-  var n = totalSize;
-
-  if n != n2 {
-    halt("File sizes do not match (",
-         totalSize, " vs ", n2, ") ",
-         "-- does the input file correspond to the unique file?");
+  if inputFilesList.size == 0 {
+    writeln("please specify input files and directories");
+    return 1;
+  }
+  if UNIQUE_DIR == "" {
+    writeln("please use --unique <dir> to specify a directory containing .unique files");
+    writeln("FindUnique can generate such a directory");
+    return 1;
+  }
+  if K == 0 && SHIFTS {
+    writeln("please set --k=<number> for use with --shifts");
+    return 1;
   }
 
 
-  var useFilename = Path.basename(INPUT);
-  if !REPLACE_FILENAME.isEmpty() {
-    useFilename = REPLACE_FILENAME;
+  // compute the paths array
+  var inputPaths = inputFilesList.toArray();
+  for p in inputPaths {
+    p = Path.normPath(p);
+  }
+  Sort.sort(inputPaths);
+
+  // compute the concise paths array
+  var concisePaths = inputPaths;
+  trimPaths(concisePaths);
+
+  // compute the unique files paths array
+  var uniquePaths = concisePaths;
+  for p in uniquePaths {
+    var p1 = Path.normPath(UNIQUE_DIR + "/" + p + ".unique");
+    var b = Path.basename(p);
+    var p2 = Path.normPath(UNIQUE_DIR + "/" + b + ".unique");
+    if FileSystem.isFile(p1) {
+      p = p1;
+    } else if FileSystem.isFile(p2) {
+      p = p2;
+    } else {
+      halt("Could not find unique file at ", p1);
+    }
   }
 
-  var curDesc: string = "-";
-  var curSequence = -1;
-  for i in 0..<n {
-    const len = MinUnique[i]: int;
-    if len > 0 && (K == 0 || len <= K) {
-      const useK = if K == 0 then len else K;
-      const amtBefore = (useK-len)/2;
-      var startOffset = max(i - amtBefore, 0); // don't go before
+  {
+    // check that the unique files paths are unique
+    var s:Set.set(string);
+    for (f,p) in zip(inputPaths, uniquePaths) {
+      if s.contains(p) {
+        halt("could not find non-ambiguous unique file for ", f);
+      }
+      s.add(p);
+    }
+  }
 
-      // output the kmer if it doesn't go beyond the end
-      if startOffset + useK <= n {
-        var ignoreDueToSequenceBoundary = false;
-        if isFasta {
-          for j in 0..<useK {
-            if allData[startOffset+j] == ">".toByte() {
-              ignoreDueToSequenceBoundary = true;
+  var nFiles = inputPaths.size;
+
+  // now process all of the files together
+  // this could be parallel if it didn't mean that the output
+  // would be interleaved
+  for (inputPath, concisePath, uniquePath, fileIdx)
+  in zip(inputPaths, concisePaths, uniquePaths, inputPaths.domain) {
+    const isFasta = isFastaFile(inputPath);
+
+    // Read just the one file being processed here
+    var inputFilesList: List.list(string);
+    inputFilesList.pushBack(inputPath);
+
+    const allData; //: [] uint(8);
+    const allPaths; //: [] string;
+    const concisePaths; // : [] string
+    const fileStarts; //: [] int;
+    const totalSize: int;
+    const sequenceDescriptions; //: [] string;
+    const sequenceStarts; //: [] int;
+    readAllFiles(inputFilesList,
+                 Locales,
+                 allData=allData,
+                 allPaths=allPaths,
+                 concisePaths=concisePaths,
+                 fileStarts=fileStarts,
+                 totalSize=totalSize,
+                 sequenceDescriptions=sequenceDescriptions,
+                 sequenceStarts=sequenceStarts,
+                 skipDescriptions=false);
+
+    var uniqueF = IO.open(uniquePath, IO.ioMode.r);
+    const n2 = uniqueF.size;
+    var MinUnique:[0..<n2] uint(8);
+    uniqueF.reader().readAll(MinUnique);
+    uniqueF.close();
+
+    var n = totalSize;
+
+    if n != n2 {
+      halt("File sizes do not match (",
+           totalSize, " vs ", n2, ") ",
+           "-- does the input file correspond to the unique file?");
+    }
+
+    var useFilename = concisePath;
+    useFilename = escapeString(useFilename);
+
+    var curDesc: string = "-";
+    var curSequence = -1;
+    var curSequenceStart = 0;
+    for i in 0..<n {
+      const len = MinUnique[i]: int;
+      if len > 0 && (K == 0 || len <= K) {
+        const useK = if K == 0 then len else K;
+        var startOffset:int = i;
+        if K != 0 {
+          const amtBefore = if SHIFTS then useK-len else (useK-len)/2;
+          // set startOffset to i - amtBefore,
+          // but don't go negative and don't pass a sequence boundary
+          // (>)
+          if isFasta {
+            var j = 0;
+            while i - j >= 0 && j <= amtBefore {
+              if allData[i - j] == ">".toByte() {
+                break;
+              }
+              j += 1;
+            }
+            startOffset = i - j;
+          } else {
+            startOffset = i - amtBefore;
+          }
+          // startOffset should not be negative
+          startOffset = max(startOffset, 0);
+          // startOffset should not be larger than the position unique starts
+          startOffset = min(startOffset, i);
+        }
+
+        var skip = true;
+        if startOffset + useK <= n {
+          skip = false;
+          if isFasta {
+            // skip any sequences that contain the sequence boundary >
+            for j in 0..<useK {
+              if allData[startOffset+j] == ">".toByte() {
+                skip = true;
+              }
             }
           }
         }
 
-        if !ignoreDueToSequenceBoundary {
+        if !skip {
+          // update the current sequence description
           var seqIdx = offsetToFileIdx(sequenceStarts, i);
           if curSequence != seqIdx {
             curSequence = seqIdx;
+            curSequenceStart = sequenceStarts[curSequence];
             curDesc = sequenceDescriptions[curSequence];
             curDesc = normalizeDesc(curDesc);
-          }
-          for j in 0..<useK {
-            writef("%c", allData[startOffset + j]);
+            if OUTPUT_TSV {
+              curDesc = replaceSpacesWithUnderlines(curDesc);
+            }
+            curDesc = escapeString(curDesc);
           }
 
-          write(" 0 ", useFilename, " 1 ", curDesc, " ", i);
-          writeln();
+          if SHIFTS {
+            for curStartOffset in startOffset..i {
+              // stop if the end of the sequence is beyond the end of the string
+              if curStartOffset + useK > n {
+                break;
+              }
+              // stop if there is an > at the starting offset
+              if isFasta && allData[curStartOffset] == ">".toByte() {
+                break;
+              }
+              // or if there is one at useK-1
+              if isFasta && allData[curStartOffset+useK-1] == ">".toByte() {
+                break;
+              }
+
+              // output the kmer at this shift
+              outputKmer(offset=curStartOffset,
+                         uniqueLen=len,
+                         outputLen=useK,
+                         startOffsetInSequence=curStartOffset-curSequenceStart,
+                         uniqueOffsetInSequence=i-curSequenceStart,
+                         fileIdx=fileIdx,
+                         nFiles=nFiles,
+                         allData=allData,
+                         useFilename=useFilename,
+                         curDesc=curDesc,
+                         isFasta=isFasta);
+            }
+          } else {
+            outputKmer(offset=startOffset,
+                       uniqueLen=len,
+                       outputLen=useK,
+                       startOffsetInSequence=startOffset-curSequenceStart,
+                       uniqueOffsetInSequence=i-curSequenceStart,
+                       fileIdx=fileIdx,
+                       nFiles=nFiles,
+                       allData=allData,
+                       useFilename=useFilename,
+                       curDesc=curDesc,
+                       isFasta=isFasta);
+          }
         }
       }
     }

--- a/src/ssort_chpl/StackTrace.chpl
+++ b/src/ssort_chpl/StackTrace.chpl
@@ -1,0 +1,47 @@
+/*
+  2025 Michael Ferguson <michaelferguson@acm.org>
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  femto/src/ssort_chpl/StackTrace.chpl
+*/
+
+module StackTrace {
+
+
+import CTypes.{c_ptr, c_char};
+import ChplConfig.CHPL_UNWIND;
+
+private extern proc chpl_stack_unwind_to_string(sep: uint(8)): c_ptr(c_char);
+
+/* Computes a stack trace and returns it as a string.
+   Trace entries are separated by the first byte in 'sep',
+   or newline if it is empty. */
+proc stackTraceAsString(sep: bytes = b"\n"): string { 
+  if CHPL_UNWIND == "none" {
+    compilerWarning("stackTraceAsString always returns the empty string in this configuration. Please recompile with CHPL_UNWIND=system or CHPL_UNWIND=bundled");
+  }
+  var useSep: uint(8) = "\n".toByte();
+  if sep.size > 0 {
+    useSep = sep[0];
+  }
+
+  var buf = chpl_stack_unwind_to_string(useSep);
+
+  var s = try! string.createAdoptingBuffer(buf);
+  return s;
+}
+
+
+}

--- a/src/ssort_chpl/SuffixSort.chpl
+++ b/src/ssort_chpl/SuffixSort.chpl
@@ -61,6 +61,7 @@ private import Time;
 private import List;
 private import Help;
 private import CommDiagnostics;
+private import MemDiagnostics;
 
 proc computeSuffixArray(Input: [], const n: Input.domain.idxType) {
   if !(Input.domain.rank == 1 &&

--- a/src/ssort_chpl/SuffixSortImpl.chpl
+++ b/src/ssort_chpl/SuffixSortImpl.chpl
@@ -35,6 +35,7 @@ import Reflection;
 import CTypes.{c_sizeof,c_int};
 import Time;
 import CachedAggregators.{CachedSrcAggregator,CachedDstAggregator};
+import CopyAggregation.SrcAggregator;
 //import MemDiagnostics;
 
 import SuffixSort.DEFAULT_PERIOD;
@@ -946,7 +947,7 @@ proc loadNextWords(const cfg:ssortConfig(?),
     // see https://github.com/chapel-lang/chapel/issues/26685
     var myReadAgg = if outerReadAgg.type != nothing
                     then none
-                    else new CachedSrcAggregator(wordType);
+                    else new SrcAggregator(wordType);
     ref readAgg = if outerReadAgg.type != nothing
                   then outerReadAgg
                   else myReadAgg;
@@ -1712,7 +1713,7 @@ proc sortAndNameSampleOffsets(const cfg:ssortConfig(?),
       var LocA: [0..<bufSz] offsetAndCachedType;
       var LocScratch: [0..<bufSz] offsetAndCachedType;
       var LocBucketBoundaries: [0..<bufSz] uint(8);
-      var readAgg = new CachedSrcAggregator(wordType);
+      var readAgg = new SrcAggregator(wordType);
       var bktAgg = new CachedDstAggregator(uint(8));
       mysubtimes.allocateTime.accumulate(allocateTime);
 
@@ -2147,10 +2148,10 @@ proc sortAllOffsetsInRegion(const cfg:ssortConfig(?),
                             ref LocSampleRanksA: [] offsetAndSampleRanks(?),
                             ref LocSampleRanksScratch: [] offsetAndSampleRanks(?),
                             ref LocBucketBoundaries: [] uint(8),
-                            ref readAgg: CachedSrcAggregator(cfg.loadWordType),
+                            ref readAgg: SrcAggregator(cfg.loadWordType),
                             ref bktAgg: CachedDstAggregator(uint(8)),
                             ref rankReadAgg:
-                              CachedSrcAggregator(cfg.unsignedOffsetType),
+                              SrcAggregator(cfg.unsignedOffsetType),
                             ref outputAgg: CachedDstAggregator(cfg.offsetType),
                             ref subtimes: sortAllOffsetsSubtimes
                             /*ref readAgg: SrcAggregator(cfg.loadWordType),
@@ -2469,9 +2470,9 @@ proc sortAllOffsets(const cfg:ssortConfig(?),
     var LocSampleRanksA: [0..<bufSz] offsetAndSampleRanksType;
     var LocSampleRanksScratch: [0..<bufSz] offsetAndSampleRanksType;
 
-    var readAgg = new CachedSrcAggregator(wordType);
+    var readAgg = new SrcAggregator(wordType);
     var bktAgg = new CachedDstAggregator(uint(8));
-    var rankReadAgg = new CachedSrcAggregator(rankType);
+    var rankReadAgg = new SrcAggregator(rankType);
     var outputAgg = new CachedDstAggregator(offsetType);
     mysubtimes.allocateTime.accumulate(allocateTime);
 

--- a/src/ssort_chpl/TestCachedAggregators.chpl
+++ b/src/ssort_chpl/TestCachedAggregators.chpl
@@ -1,0 +1,54 @@
+/*
+  2024 Michael Ferguson <michaelferguson@acm.org>
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  femto/src/ssort_chpl/CachedAggregators.chpl
+*/
+
+module TestUtility {
+
+use CachedAggregators;
+use BlockDist;
+
+config const n = 1_000_000;
+
+proc testCachedDstAggregator() {
+  writeln("testCachedDstAggregator");
+
+  // store numbers in forward order in Fwd
+  var Fwd =  blockDist.createArray(0..<n, int);
+  Fwd = 0..<n;
+
+  // store numbers in reverse order in Rev
+  var Rev = blockDist.createArray(0..<n, int);
+  Rev = 0..<n by -1;
+
+  var A = Rev;
+  assert(A.equals(Rev));
+
+  var B = blockDist.createArray(0..<n, int);
+
+  // Set B to the elements of Rev reordered by value
+  B = 0;
+  forall elt in A with (var agg = new CachedDstAggregator()) {
+    agg.copy(B[elt], elt);
+  }
+  assert(B.equals(Fwd));
+}
+
+testCachedDstAggregator();
+writeln("Done");
+
+}

--- a/src/ssort_chpl/TestCachedAggregators.chpl
+++ b/src/ssort_chpl/TestCachedAggregators.chpl
@@ -42,7 +42,7 @@ proc testCachedDstAggregator() {
 
   // Set B to the elements of Rev reordered by value
   B = 0;
-  forall elt in A with (var agg = new CachedDstAggregator()) {
+  forall elt in A with (var agg = new CachedDstAggregator(int)) {
     agg.copy(B[elt], elt);
   }
   assert(B.equals(Fwd));
@@ -50,7 +50,7 @@ proc testCachedDstAggregator() {
   // test a simple flush scenario
   {
     A = Rev;
-    var agg = new CachedDstAggregator();
+    var agg = new CachedDstAggregator(int);
     agg.copy(A[n-1], 42);
     agg.flush();
     assert(A[n-1] == 42);
@@ -76,7 +76,7 @@ proc testCachedSrcAggregator() {
   B = 0;
   // Set B to the elements of A reordered by value
   forall (elt, i) in zip(B, B.domain)
-  with (var agg = new CachedSrcAggregator()) {
+  with (var agg = new CachedSrcAggregator(int)) {
     agg.copy(elt, A[n-1-i]);
   }
   assert(B.equals(Fwd));
@@ -85,7 +85,7 @@ proc testCachedSrcAggregator() {
   {
     A = Rev;
     A[n-1] = 42;
-    var agg = new CachedSrcAggregator();
+    var agg = new CachedSrcAggregator(int);
     var x = 0;
     agg.copy(x, A[n-1]);
     agg.flush();

--- a/src/ssort_chpl/TestCachedAggregators.chpl
+++ b/src/ssort_chpl/TestCachedAggregators.chpl
@@ -46,9 +46,55 @@ proc testCachedDstAggregator() {
     agg.copy(B[elt], elt);
   }
   assert(B.equals(Fwd));
+
+  // test a simple flush scenario
+  {
+    A = Rev;
+    var agg = new CachedDstAggregator();
+    agg.copy(A[n-1], 42);
+    agg.flush();
+    assert(A[n-1] == 42);
+  }
+}
+proc testCachedSrcAggregator() {
+  writeln("testCachedSrcAggregator");
+
+  // store numbers in forward order in Fwd
+  var Fwd =  blockDist.createArray(0..<n, int);
+  Fwd = 0..<n;
+
+  // store numbers in reverse order in Rev
+  var Rev = blockDist.createArray(0..<n, int);
+  Rev = 0..<n by -1;
+
+  var A = Rev;
+  assert(A.equals(Rev));
+
+  var B = blockDist.createArray(0..<n, int);
+
+  // Set B to the elements of Rev reordered by value
+  B = 0;
+  // Set B to the elements of A reordered by value
+  forall (elt, i) in zip(B, B.domain)
+  with (var agg = new CachedSrcAggregator()) {
+    agg.copy(elt, A[n-1-i]);
+  }
+  assert(B.equals(Fwd));
+
+  // test a simple flush scenario
+  {
+    A = Rev;
+    A[n-1] = 42;
+    var agg = new CachedSrcAggregator();
+    var x = 0;
+    agg.copy(x, A[n-1]);
+    agg.flush();
+    assert(x == 42);
+  }
 }
 
 testCachedDstAggregator();
+testCachedSrcAggregator();
 writeln("Done");
 
 }

--- a/src/ssort_chpl/TestCachedAggregators.chpl
+++ b/src/ssort_chpl/TestCachedAggregators.chpl
@@ -23,6 +23,8 @@ use CachedAggregators;
 use BlockDist;
 use Random;
 
+config param EXTRA_CHECKS=false;
+
 proc testCachedDstAggregator(n:int) {
   // store numbers in forward order in Fwd
   var Fwd =  blockDist.createArray(0..<n, int);

--- a/src/ssort_chpl/TestCachedAggregators.chpl
+++ b/src/ssort_chpl/TestCachedAggregators.chpl
@@ -36,6 +36,7 @@ proc testCachedDstAggregator(n:int) {
   assert(A.equals(Rev));
 
   var B = blockDist.createArray(0..<n, int);
+  var C = blockDist.createArray(0..<n, int);
 
   // Set B to the elements of Rev reordered by value
   B = 0;
@@ -43,6 +44,19 @@ proc testCachedDstAggregator(n:int) {
     agg.copy(B[elt], elt);
   }
   assert(B.equals(Fwd));
+
+  // Set B and C to the elements of Rev reordered by value
+  B = 0;
+  C = 0;
+  forall elt in A
+  with (var bAgg = new CachedDstAggregator(int),
+        var cAgg = new CachedDstAggregator(int)) {
+    bAgg.copy(B[elt], elt);
+    cAgg.copy(C[elt], elt);
+  }
+  assert(B.equals(Fwd));
+  assert(C.equals(Fwd));
+
 
   // test a simple flush scenario
   {
@@ -91,7 +105,12 @@ proc testCachedSrcAggregator(n:int) {
   var A = Rev;
   assert(A.equals(Rev));
 
+  var AA = Rev;
+  assert(AA.equals(Rev));
+
   var B = blockDist.createArray(0..<n, int);
+
+  var C = blockDist.createArray(0..<n, int);
 
   // Set B to the elements of Rev reordered by value
   B = 0;
@@ -101,6 +120,18 @@ proc testCachedSrcAggregator(n:int) {
     agg.copy(elt, A[n-1-i]);
   }
   assert(B.equals(Fwd));
+
+  // Set B and C to the elements of Rev reordered by value
+  B = 0;
+  C = 0;
+  forall (bElt, cElt, i) in zip(B, C, B.domain)
+  with (var bAgg = new CachedSrcAggregator(int),
+        var cAgg = new CachedSrcAggregator(int)) {
+    bAgg.copy(bElt, A[n-1-i]);
+    cAgg.copy(cElt, AA[n-1-i]);
+  }
+  assert(B.equals(Fwd));
+  assert(C.equals(Fwd));
 
   // test a simple flush scenario
   {
@@ -112,6 +143,7 @@ proc testCachedSrcAggregator(n:int) {
     agg.flush();
     assert(x == 42);
   }
+
 }
 proc testCachedSrcAggregatorRandom(n: int, seed: int) {
   writeln("testCachedSrcDstAggregatorRandom(n=", n, ", seed=", seed, ")");

--- a/src/ssort_chpl/TestStackTrace.chpl
+++ b/src/ssort_chpl/TestStackTrace.chpl
@@ -1,0 +1,43 @@
+/*
+  2025 Michael Ferguson <michaelferguson@acm.org>
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  femto/src/ssort_chpl/TestStackTrace.chpl
+*/
+
+module TestStackTrace {
+
+
+use StackTrace;
+
+proc baz() {
+  var s = stackTraceAsString(b"|");
+  writeln(s);
+}
+
+proc bar() {
+  baz();
+}
+proc foo() {
+  bar();
+}
+
+proc main() { 
+  foo();
+  writeln("OK");
+}
+
+
+}

--- a/src/ssort_chpl/TestStackTrace.chpl
+++ b/src/ssort_chpl/TestStackTrace.chpl
@@ -19,6 +19,7 @@
 
 module TestStackTrace {
 
+config param EXTRA_CHECKS=false;
 
 use StackTrace;
 

--- a/src/ssort_chpl/Utility.chpl
+++ b/src/ssort_chpl/Utility.chpl
@@ -2094,6 +2094,8 @@ proc reportStat(const ref x:substat(?), desc:string) {
   }
 }
 
+// help to yield occasionally. AFAIK this is not necessary for performance,
+// but I was worried about it.
 record yieldHelper {
   var itersSinceLastYield: int;
 }

--- a/src/ssort_chpl/Utility.chpl
+++ b/src/ssort_chpl/Utility.chpl
@@ -35,8 +35,7 @@ import ChplConfig.CHPL_COMM;
 import RangeChunk;
 import Version;
 import Time;
-import CopyAggregation;
-import CopyAggregation.DstAggregator;
+import CachedAggregators.{CachedSrcAggregator,CachedDstAggregator};
 import Communication;
 import OS.FileNotFoundError;
 
@@ -908,7 +907,7 @@ proc reverseComplement(const ref input: [] uint(8),
   const n = inputRegion.size;
   forall (_, _, chunk)
   in divideIntoTasks(input.domain, inputRegion, nTasksPerLocale) {
-    var agg = new CopyAggregation.DstAggregator(uint(8));
+    var agg = new CachedDstAggregator(uint(8));
     for inputIdx in chunk {
       const i = inputIdx - inputRegion.first;
       const outputIdx = n - 1 - i + outputRegion.first;
@@ -1147,7 +1146,7 @@ proc readFastaFileSequence(path: string,
   // read in the data for each task
   forall (activeLocIdx, taskIdInLoc, chunk)
   in divideIntoTasks(Dom, 0..<size, nTasksPerLocale, activeLocs)
-  with (var agg = new DstAggregator(uint(8))) {
+  with (var agg = new CachedDstAggregator(uint(8))) {
     const taskId = activeLocIdx*nTasksPerLocale + taskIdInLoc;
     const end = Ends[taskId];
     const count = Counts[taskId];
@@ -1273,7 +1272,7 @@ proc parReadAll(path: string,
   // read in parallel
   forall (activeLocIdx, taskIdInLoc, chunk)
   in divideIntoTasks(Dom, 0..<size, nTasksPerLocale, activeLocs) {
-    var agg = new DstAggregator(uint(8));
+    var agg = new CachedDstAggregator(uint(8));
     var r = IO.openReader(path, locking=false, region=chunk);
     for fileOffset in chunk {
       var byte: uint(8);
@@ -1520,7 +1519,7 @@ proc hashAllFiles(const allData: [] uint(8),
   forall (activeLocIdx, taskIdInLoc, chunk)
   in divideIntoTasks(allData.domain, 0..<totalSize, nTasksPerLocale, activeLocs)
   with (const locFileStarts = localCopyOfBlockArr(fileStarts),
-        var agg = new DstAggregator(8*uint(32))) {
+        var agg = new CachedDstAggregator(8*uint(32))) {
     // compute the first file starting within the chunk
     var firstFile: int;
     var firstFileStart: int;

--- a/src/ssort_chpl/Utility.chpl
+++ b/src/ssort_chpl/Utility.chpl
@@ -1461,6 +1461,43 @@ proc readAllFiles(const ref files: list(string),
   }
 }
 
+proc generateAllData(n: int, seed: int,
+                     locales: [ ] locale,
+                     out allData: [] uint(8),
+                     out allPaths: [] string,
+                     out concisePaths: [] string,
+                     out fileStarts: [] int,
+                     out totalSize: int,
+                     out sequenceDescriptions: [] string,
+                     out sequenceStarts: [] int) throws {
+  const total = n;
+  var thetext = makeBlockArray(0..<total+INPUT_PADDING, Locales, uint(8));
+  var paths = makeBlockArray(0..1, Locales, string);
+  paths[0] = "<random>";
+  var tPaths = makeBlockArray(0..1, Locales, string);
+  tPaths[0] = "<random>";
+  var starts = makeBlockArray(0..1, Locales, int);
+  starts[0] = 0;
+  starts[1] = total;
+  var theSequenceDescriptions = makeBlockArray(0..1, Locales, string);
+  theSequenceDescriptions[0] = "<random>";
+  var theSequenceStarts = makeBlockArray(0..1, Locales, int);
+  theSequenceStarts[0] = 0;
+  theSequenceStarts[1] = total;
+
+  // set the data to random data
+  fillRandom(thetext, seed=seed);
+
+  allData = thetext;
+  allPaths = paths;
+  concisePaths = tPaths;
+  fileStarts = starts;
+  totalSize = total;
+
+  sequenceDescriptions = theSequenceDescriptions;
+  sequenceStarts = theSequenceStarts;
+}
+
 /* Write a Block-distributed array to a file */
 proc writeBlockArray(const in path: string, const A: [], region: range) throws {
   if A.domain.rank != 1 {


### PR DESCRIPTION
About the cached aggregators:

* radix sort performance is not impacted
* suffix sort appears to be a bit slower due to the SrcAggregator being slower, so I had that use the original SrcAggregator
* it does not seem to help with memory usage